### PR TITLE
Don't run live test if API secret key is not defined

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install: pip install . --use-mirrors
 before_script: python setup.py testdep
 script:
 - python setup.py test
-- python setup.py livetest
+- test -z "$STORMPATH_SDK_TEST_API_KEY_SECRET" || python setup.py livetest
 branches:
   only:
   - master


### PR DESCRIPTION
Travis doesn't export the secure data (API secret key) when
building pull requests (rightly so, as otherwise anyone could
use the secret key, they would just need to submit a pull request).

This means all the pull request builds fail, which is annoying and
easily hides actual errors.
