### PR TITLE
Transient sp http status

### DIFF
--- a/stormpath/resources/custom_data.py
+++ b/stormpath/resources/custom_data.py
@@ -27,6 +27,7 @@ class CustomData(Resource, DeleteMixin, SaveMixin):
         'modified_at',
         'spmeta',
         'sp_meta',
+        'sp_http_status',
     )
 
     def __init__(self, *args, **kwargs):

--- a/tests/mocks/test_custom_data.py
+++ b/tests/mocks/test_custom_data.py
@@ -12,6 +12,7 @@ class TestCustomData(TestCase):
     def setUp(self):
         self.props = {
             'href': 'test/resource',
+            'sp_http_status': 200,
             'createdAt': 123,
             'foo': 1,
             'bar': '2',
@@ -98,6 +99,7 @@ class TestCustomData(TestCase):
 
         del self.props['href']
         del self.props['createdAt']
+        del self.props['sp_http_status']
 
         self.assertEqual(d._get_properties(), self.props)
 


### PR DESCRIPTION
Ensure that sp_http_status attribute is not treated as a custom attribute (and never sent to the server).
