### PR TITLE
Update api docs to better describe tokens

### DIFF
--- a/stormpath/resources/application.py
+++ b/stormpath/resources/application.py
@@ -133,14 +133,14 @@ class Application(Resource, DeleteMixin, DictMixin, AutoSaveMixin, SaveMixin, St
     def verify_password_reset_token(self, token):
         """Verify password reset by using a token.
 
-        :param token: password reset token extracted from the URL.
+        :param token: a string representation of the password reset token extracted from the URL.
         """
         return self.password_reset_tokens[token].account
 
     def reset_account_password(self, token, password):
         """Resets the password for an account.
 
-        :param token: password reset token.
+        :param token: A :class:`stormpath.resources.password_reset_token.PasswordResetToken` object.
         :param password: new password
         """
         if token.account.email not in [a.email for a in self.accounts]:


### PR DESCRIPTION
This better describes what we mean by `token` as a parameter in `verify_password_reset_token` and `reset_account_password` password application methods.

@rdegges One more thing...do you think we should emphasize in the docs that the correct method to use here is `reset_account_password`? Since this was added to be able to do the reset in one call, rather than having to generate, send, verify a token in separate steps? It was my understanding that `reset_account_password` essentially made the manual steps private API, in a way.
