### PR TITLE
make sure custom_data elem in dict works

### DIFF
--- a/stormpath/resources/custom_data.py
+++ b/stormpath/resources/custom_data.py
@@ -64,6 +64,7 @@ class CustomData(Resource, DeleteMixin, SaveMixin):
             self._deletes.add(self._get_key_href(key))
 
     def __contains__(self, key):
+        self._ensure_data()
         return key in self.data
 
     def _get_key_href(self, key):

--- a/tests/mocks/test_custom_data.py
+++ b/tests/mocks/test_custom_data.py
@@ -279,6 +279,22 @@ class TestCustomData(TestCase):
                 'subResource': cd
             }, params={})
 
+    def test_cusom_data_elem_in_dict_check(self):
+        ds = MagicMock()
+        ds.get_resource.return_value = {
+                'href': 'test/customData',
+                'test': 1
+        }
+        from stormpath.resources.account import Account
+        client = MagicMock(data_store=ds)
+        client.accounts.get.return_value = Account(client, properties={
+                'href': 'test/account',
+                'custom_data': {'href': 'test/customData'}
+        })
+        a = client.accounts.get('test/account')
+
+        self.assertTrue('test' in a.custom_data)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Makes sure custom data dict 'in' checks work as expected. Fixes #89 
