### PR TITLE
fix search query encoding

### DIFF
--- a/stormpath/auth.py
+++ b/stormpath/auth.py
@@ -60,9 +60,6 @@ class Sauthc1Signer(AuthBase):
             if key in query:
                 query = query.replace(key, value)
 
-        str = '%2F'
-        query = query.replace(str, '/') if str in query else query
-
         return query
 
     def __call__(self, r):


### PR DESCRIPTION
@rdegges  This fixes #72 and #39.

I've tested both cases with "/" and "&" (with or without combining wildcards) and it works now.
