### PR TITLE
make password reset flows consistent

### DIFF
--- a/stormpath/resources/application.py
+++ b/stormpath/resources/application.py
@@ -140,9 +140,10 @@ class Application(Resource, DeleteMixin, DictMixin, AutoSaveMixin, SaveMixin, St
     def reset_account_password(self, token, password):
         """Resets the password for an account.
 
-        :param token: A :class:`stormpath.resources.password_reset_token.PasswordResetToken` object.
+        :param token: a string representation of the password reset token extracted from the URL.
         :param password: new password
         """
+        token = self.password_reset_tokens[token]
         if token.account.email not in [a.email for a in self.accounts]:
             raise ValueError('Unrecognized account for this application %s' %
                 repr(token.account))

--- a/tests/live/test_account.py
+++ b/tests/live/test_account.py
@@ -102,7 +102,7 @@ class TestPasswordReset(AccountBase):
 
         new_pwd = 'W00t123!' + self.get_random_name()
 
-        self.app.reset_account_password(token, new_pwd)
+        self.app.reset_account_password(token.token, new_pwd)
 
         auth = self.app.authenticate_account(self.acc.username, new_pwd)
         self.assertEqual(auth.account.href, self.acc.href)


### PR DESCRIPTION
reset_account_password now takes a token as a string representation.
This makes sense because the string is going to be extracted from the
URL anyway, the method handles the object creation and password reset
as usual. This change is to be consistent with
verify_password_reset_token which also takes a string.
