### PR TITLE
Added collection size property

### DIFF
--- a/tests/live/test_resource.py
+++ b/tests/live/test_resource.py
@@ -120,7 +120,7 @@ class TestCollectionResource(AccountBase):
         expansion = Expansion()
         expansion.add_property('accounts', offset=0, limit=3)
         dir = self.client.directories.get(self.dir.href, expansion)
-        self.assertEqual(len(dir.accounts), 3)
+        self.assertEqual(len(dir.accounts), 5)
 
     def test_href_indexing(self):
         href = self.accounts[0].href


### PR DESCRIPTION
This adds the `size` property to `CollectionResource` and makes use of it for checking the length of a collection, iterating over it, pagination etc. We make sure not to make an extra HTTP request when paginating like we did before. 

Also, this fixes a number of bugs/unexpected behavior with the way collections worked before (like len(coll) returning 25 (the default page limit) instead of the actual full size and various others issues).

I've had a lot of trouble with this one so I'd appreciate all the review I can get (more eyes on this means less bugs).

One thing that bugs me though.... When we do a request for an `Application` we get something like as a response:
    
    {
        "href":"https://api.stormpath.com/v1/applications/APPID",
        "name":"bla",
        "description":"bla",
        "status":"ENABLED",
        "groups":{"href":"https://api.stormpath.com/v1/applications/APPID/groups"}
        ......

    }

Now, for me it makes sense if the the `size` property was returned here, along with the href (for collections only, like groups), because currently we need to first fetch the entire collection to get the size property that we then need to use for pagination, length checking and so on (this makes for some weird code/edge cases....not to mention hurts performance). @rdegges what do you think?