### PR TITLE
Fix for https://github.com/stormpath/stormpath-django/issues/20

### DIFF
--- a/stormpath/resources/base.py
+++ b/stormpath/resources/base.py
@@ -356,17 +356,8 @@ class CollectionResource(Resource):
         return items
 
     def __iter__(self):
-        try:
-            items = self.__dict__['items']
-        except:
-            # We don't want to do an unnecessary API call cause chances are
-            # that we alreay tried to fetch self.size which in trun needed to fetch the collection.
-            # If however it's our first time iterating over the collection we do need to fetch the data.
-            # This is kinda silly but it would help if the API returned the size property upfront
-            # without needing to first fetch the collection to get the size property.
-            # (We check the size property in _get_next_page effectively making an API call if it's not there)
-            self._ensure_data()
-            items = self.__dict__['items']
+        self._ensure_data()
+        items = self.__dict__['items']
 
         offset = self.__dict__['offset']
         limit = self.__dict__['limit']
@@ -390,9 +381,7 @@ class CollectionResource(Resource):
         self._query['limit'] = self.__dict__['limit']
 
     def __len__(self):
-        # We don't need to call self._ensure_data() here because touching the
-        # size property will do that anyway
-
+        self._ensure_data()
         return self.__dict__.get('_sliced_size', self.size)
 
     def __getitem__(self, idx):

--- a/tests/mocks/test_resource.py
+++ b/tests/mocks/test_resource.py
@@ -416,6 +416,89 @@ class TestCollectionResource(TestCase):
         hrefs = [r.href for r in rl]
         self.assertTrue(hrefs, ['test/resource', 'another/resource'])
 
+    def test_len(self):
+        ds = MagicMock()
+        ds.get_resource.return_value = {
+            'href': '/',
+            'offset': 0,
+            'limit': 25,
+            'size': 2,
+            'items': [
+                {'href': 'test/resource'},
+                {'href': 'another/resource'}
+            ]
+        }
+
+        rl = CollectionResource(client=MagicMock(data_store=ds), href='/')
+
+        len_rl = len(rl)
+        # assert that it will get resource from data store
+        self.assertEqual(ds.get_resource.call_count, 1)
+        # assert that it will get the right len
+        self.assertEqual(len_rl, 2)
+
+        ds.get_resource.return_value = {
+            'href': '/',
+            'offset': 0,
+            'limit': 25,
+            'size': 3,
+            'items': [
+                {'href': 'test/resource'},
+                {'href': 'another/resource'},
+                {'href': 'third/resource'}
+            ]
+        }
+
+        len_rl = len(rl)
+        # assert that it will get resource from data store again
+        self.assertEqual(ds.get_resource.call_count, 2)
+        # assert that it will get the new len
+        self.assertEqual(len_rl, 3)
+
+    def test_iter(self):
+        ds = MagicMock()
+        ds.get_resource.return_value = {
+            'href': '/',
+            'offset': 0,
+            'limit': 25,
+            'size': 2,
+            'items': [
+                {'href': 'test/resource'},
+                {'href': 'another/resource'}
+            ]
+        }
+
+        rl = CollectionResource(client=MagicMock(data_store=ds), href='/')
+
+        hrefs = []
+        for r in rl:
+            hrefs.append(r.href)
+        # assert that it will get resource from data store
+        self.assertEqual(ds.get_resource.call_count, 1)
+        # assert that it will get the right hrefs
+        self.assertEqual(hrefs, ['test/resource', 'another/resource'])
+
+        ds.get_resource.return_value = {
+            'href': '/',
+            'offset': 0,
+            'limit': 25,
+            'size': 3,
+            'items': [
+                {'href': 'test/resource'},
+                {'href': 'another/resource'},
+                {'href': 'third/resource'}
+            ]
+        }
+
+        hrefs = []
+        for r in rl:
+            hrefs.append(r.href)
+        # assert that it will get resource from data store again
+        self.assertEqual(ds.get_resource.call_count, 2)
+        # assert that it will get the new hrefs
+        self.assertEqual(
+            hrefs, ['test/resource', 'another/resource', 'third/resource'])
+
     def test_limit_offset_query(self):
         ds = MagicMock()
         ds.get_resource.return_value = {

--- a/tests/mocks/test_resource.py
+++ b/tests/mocks/test_resource.py
@@ -483,7 +483,7 @@ class TestCollectionResource(TestCase):
         self.assertEqual(hrefs, ['test/resource', 'another/resource',
             'third/resource'])
 
-        ds.get_resource.assert_called_with('/', params=None)
+        ds.get_resource.assert_any_call('/', params=None)
 
         self.assertEqual(len(rl), 3)
         self.assertEqual(rl.offset, 2)


### PR DESCRIPTION
This is just quick temporary fix for failing tests on stormpath-django repo. This problem should be fixed properly and then this fix should probably be reverted because it does unnecessary API calls.

All I did is put _ensure_data() calls back where they were because without that calls it uses local memory data which is stale for the failing tests. I'll investigate further.