### PR TITLE
Deleting CustomData should delete its items.

### DIFF
--- a/stormpath/resources/custom_data.py
+++ b/stormpath/resources/custom_data.py
@@ -120,3 +120,7 @@ class CustomData(Resource, DeleteMixin, SaveMixin):
 
         if 'data' in self.__dict__ and len(self.data):
             super(CustomData, self).save()
+
+    def delete(self):
+        super(CustomData, self).delete()
+        self.__dict__['data'] = {}

--- a/tests/live/test_custom_data.py
+++ b/tests/live/test_custom_data.py
@@ -336,3 +336,13 @@ class TestTenantCustomData(SingleApplicationBase):
         res = self.client.tenant
 
         self.assertEqual(dict(res.custom_data), {})
+
+    def test_custom_data_deletion(self):
+        res = self.client.tenant
+        self.assertEqual(dict(res.custom_data), {})
+
+        for key in CUSTOM_DATA.keys():
+            res.custom_data[key] = CUSTOM_DATA[key]
+
+        self.client.tenant.custom_data.delete()
+        assert dict(self.client.tenant.custom_data) == {}

--- a/tests/mocks/test_custom_data.py
+++ b/tests/mocks/test_custom_data.py
@@ -295,6 +295,16 @@ class TestCustomData(TestCase):
 
         self.assertTrue('test' in a.custom_data)
 
+    def test_custom_data_deletion(self):
+        ds = MagicMock()
+        client = MagicMock(data_store=ds)
+
+        d = CustomData(client, properties=self.props)
+        d.delete()
+
+        ds.delete_resource.assert_called_once_with(self.props['href'])
+        assert {} == dict(d)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Deleting a resource will make HTTP DELETE request to its URL and uncache it. Additionally, for CustomData, it should delete its items from the object memory, as that is exactly what HTTP DELETE does for custom data: http://docs.stormpath.com/rest/product-guide/#delete-custom-data .
Without this, custom data's object would still contain items it had before delete() is called. Added tests for this behavior.
This fixes #108 