### PR TITLE
Fixed memcached deserializer.

### DIFF
--- a/stormpath/cache/memcached_store.py
+++ b/stormpath/cache/memcached_store.py
@@ -23,7 +23,7 @@ def json_deserializer(key, value, flags):
     if flags == STR_VALUE:
         return value
     if flags == JSON_VALUE:
-        return loads(value.decode('utf-8')), 2
+        return loads(value.decode('utf-8'))
     raise Exception("Unknown serialization format")
 
 


### PR DESCRIPTION
json_deserializer() was accidentally returning tuple in case of json value. This happened as consequence of following this example: https://github.com/pinterest/pymemcache/blob/master/pymemcache/client.py#L37 .
Also, I improved tests for memcached so they include json_serializer() and json_deserializer() so this behavior is tested as well.

This fixes #116 .