### PR TITLE
Python 3 unicode fix and tests

### DIFF
--- a/stormpath/api_auth.py
+++ b/stormpath/api_auth.py
@@ -27,9 +27,9 @@ class SPBasicAuthRequestValidator(object):
         self.client_secret = None
 
     def extract_client_data(self):
-        _, b64encoded_data = self.authorization.split(b' ')
-        decoded_data = base64.b64decode(b64encoded_data)
-        self.client_id, self.client_secret = decoded_data.split(b':')
+        _, b64encoded_data = self.authorization.split(' ')
+        decoded_data = to_unicode(base64.b64decode(b64encoded_data), 'ascii')
+        self.client_id, self.client_secret = decoded_data.split(':')
 
     def verify_request(self):
         self.extract_client_data()
@@ -49,7 +49,7 @@ class AccessToken(object):
         # get raw data without validation
         try:
             data = jwt.decode(self.token, verify=False)
-            self.client_id = data.get('sub', b'')
+            self.client_id = data.get('sub', '')
             self.api_key = self.app.api_keys.get_key(self.client_id)
             self.exp = data.get('exp', 0)
             self.scopes = data.get('scope', '').split(' ')
@@ -115,8 +115,9 @@ class SPOauth2RequestValidator(Oauth2RequestValidator):
         authorization = request.headers.get('Authorization')
         try:
             auth_scheme, b64encoded_data = authorization.split(' ')
-            decoded_data = base64.b64decode(b64encoded_data.encode('utf-8'))
-            client_id, _ = decoded_data.split(b':')
+            decoded_data = to_unicode(
+                base64.b64decode(b64encoded_data.encode('utf-8')), 'ascii')
+            client_id, _ = decoded_data.split(':')
             request.client = Oauth2BackendApplicationClient(client_id)
         except Exception:
             return False
@@ -156,8 +157,8 @@ def _generate_signed_token(request):
     now = datetime.datetime.utcnow()
 
     data = {
-        'iss': request.app.href.decode('utf-8'),
-        'sub': client_id.decode('utf-8'),
+        'iss': request.app.href,
+        'sub': client_id,
         'iat': now,
         'exp': now + datetime.timedelta(seconds=request.expires_in)
     }
@@ -187,12 +188,12 @@ def _get_bearer_token(app, allowed_scopes, http_method, uri, body, headers, ttl=
 
 def _authenticate_request(app, allowed_scopes, http_method, uri, body, headers, ttl=DEFAULT_TTL):
     authorization = headers.get('Authorization')
-    auth_type = authorization.split(b' ')[0]
-    if auth_type == b'Basic':
+    auth_type = authorization.split(' ')[0]
+    if auth_type == 'Basic':
         validator = SPBasicAuthRequestValidator(app=app, headers=headers)
         valid, r = validator.verify_request()
         return valid, r
-    if auth_type == b'Bearer':
+    if auth_type == 'Bearer':
         validator = SPOauth2RequestValidator(app=app, allowed_scopes=allowed_scopes, ttl=ttl)
         server = Oauth2BackendApplicationServer(validator)
         valid, r = server.verify_request(uri, http_method, body, headers, allowed_scopes)
@@ -201,15 +202,17 @@ def _authenticate_request(app, allowed_scopes, http_method, uri, body, headers, 
 
 
 def authenticate(app, allowed_scopes, http_method, uri, body, headers, ttl=DEFAULT_TTL):
+    for k, v in headers.items():
+        headers[k] = to_unicode(v, 'ascii')
     jwt_token = None
     access_token = None
     auth_header = headers.get('Authorization')
-    auth_scheme = auth_header.split(b' ')[0]
-    if auth_scheme == b'Basic':
+    auth_scheme = auth_header.split(' ')[0]
+    if auth_scheme == 'Basic':
         if body.get('grant_type'):
             jwt_token = _get_bearer_token(app, allowed_scopes, http_method, uri, body, headers, ttl=ttl)
-    if auth_scheme == b'Bearer':
-        jwt_token = auth_header.split(b' ')[1]
+    if auth_scheme == 'Bearer':
+        jwt_token = auth_header.split(' ')[1]
     if jwt_token:
         access_token = AccessToken(app, jwt_token)
     valid, r = _authenticate_request(app, allowed_scopes, http_method, uri, body, headers, ttl=ttl)

--- a/stormpath/api_auth.py
+++ b/stormpath/api_auth.py
@@ -28,7 +28,8 @@ class SPBasicAuthRequestValidator(object):
 
     def extract_client_data(self):
         _, b64encoded_data = self.authorization.split(' ')
-        decoded_data = to_unicode(base64.b64decode(b64encoded_data), 'ascii')
+        decoded_data = to_unicode(
+            base64.b64decode(b64encoded_data.encode('utf-8')), 'ascii')
         self.client_id, self.client_secret = decoded_data.split(':')
 
     def verify_request(self):

--- a/tests/live/test_api_auth.py
+++ b/tests/live/test_api_auth.py
@@ -1,0 +1,162 @@
+"""Live tests of client authentication against the Stormpath service API."""
+import base64
+
+from .base import ApiKeyBase
+
+
+class TestApiAuth(ApiKeyBase):
+
+    def test_basic_api_authentication_succeeds(self):
+        _, acc = self.create_account(self.app.accounts)
+        api_key = self.create_api_key(acc)
+
+        headers = {
+            'Authorization':
+                b'Basic ' + base64.b64encode(
+                    "{}:{}".format(api_key.id, api_key.secret).encode('utf-8'))
+        }
+
+        result = self.app.authenticate_api(
+            allowed_scopes=[], http_method='GET', uri='some@uri.com', body={},
+            headers=headers)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(api_key.id, result.api_key.id)
+        self.assertEqual(api_key.secret, result.api_key.secret)
+        self.assertEqual(acc.href, result.api_key.account.href)
+
+    def test_basic_api_authentication_with_unicode_succeeds(self):
+        _, acc = self.create_account(self.app.accounts)
+        api_key = self.create_api_key(acc)
+
+        b64_key = base64.b64encode(
+            '{}:{}'.format(api_key.id, api_key.secret).encode('utf-8'))
+        headers = {
+            'Authorization':
+                'Basic ' + b64_key.decode('utf-8')
+        }
+
+        result = self.app.authenticate_api(
+            allowed_scopes=[], http_method='GET', uri='some@uri.com', body={},
+            headers=headers)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(api_key.id, result.api_key.id)
+        self.assertEqual(api_key.secret, result.api_key.secret)
+        self.assertEqual(acc.href, result.api_key.account.href)
+
+    def test_basic_api_authentication_fails(self):
+        _, acc = self.create_account(self.app.accounts)
+        api_key = self.create_api_key(acc)
+
+        headers = {
+            'Authorization':
+                b'Basic ' + base64.b64encode(
+                    "{}:{}".format(api_key.id, 'INVALID').encode('utf-8'))
+        }
+
+        result = self.app.authenticate_api(
+            allowed_scopes=[], http_method='GET', uri='some@uri.com', body={},
+            headers=headers)
+
+        self.assertIsNone(result)
+
+    def test_bearer_api_authentication_succeeds(self):
+        _, acc = self.create_account(self.app.accounts)
+        api_key = self.create_api_key(acc)
+
+        headers = {
+            'Authorization':
+                b'Basic ' + base64.b64encode(
+                    "{}:{}".format(api_key.id, api_key.secret).encode('utf-8'))
+        }
+        body = {'grant_type': 'client_credentials', 'scope': 's1 s2'}
+        scopes = ['s1', 's2']
+
+        result = self.app.authenticate_api(
+            allowed_scopes=scopes, http_method='GET', uri='some@uri.com',
+            body=body, headers=headers)
+
+        self.assertEqual(api_key.id, result.api_key.id)
+        self.assertEqual(api_key.secret, result.api_key.secret)
+        self.assertEqual(acc.href, result.api_key.account.href)
+        self.assertEqual(result.token.scopes, scopes)
+
+        headers = {
+            'Authorization': b'Bearer ' + result.token.token.encode('utf-8')}
+
+        result = self.app.authenticate_api(
+            allowed_scopes=scopes, http_method='GET', uri='some@uri.com',
+            body={}, headers=headers)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(acc.href, result.account.href)
+
+    def test_bearer_api_authentication_with_unicode_succeeds(self):
+        _, acc = self.create_account(self.app.accounts)
+        api_key = self.create_api_key(acc)
+
+        b64_key = base64.b64encode(
+            '{}:{}'.format(api_key.id, api_key.secret).encode('utf-8'))
+        headers = {
+            'Authorization': 'Basic ' + b64_key.decode('utf-8')
+        }
+        body = {'grant_type': 'client_credentials', 'scope': 's1 s2'}
+        scopes = ['s1', 's2']
+
+        result = self.app.authenticate_api(
+            allowed_scopes=scopes, http_method='GET', uri='some@uri.com',
+            body=body, headers=headers)
+
+        self.assertEqual(api_key.id, result.api_key.id)
+        self.assertEqual(api_key.secret, result.api_key.secret)
+        self.assertEqual(acc.href, result.api_key.account.href)
+        self.assertEqual(result.token.scopes, scopes)
+
+        headers = {
+            'Authorization': 'Bearer ' + result.token.token}
+
+        result = self.app.authenticate_api(
+            allowed_scopes=scopes, http_method='GET', uri='some@uri.com',
+            body={}, headers=headers)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(acc.href, result.account.href)
+
+    def test_bearer_api_authentication_with_wrong_token_fails(self):
+        headers = {'Authorization': b'Bearer INVALID_TOKEN'}
+
+        result = self.app.authenticate_api(
+            allowed_scopes=[], http_method='GET', uri='some@uri.com',
+            body={}, headers=headers)
+
+        self.assertIsNone(result)
+
+    def test_bearer_api_authentication_with_wrong_scope_fails(self):
+        _, acc = self.create_account(self.app.accounts)
+        api_key = self.create_api_key(acc)
+
+        headers = {
+            'Authorization':
+                b'Basic ' + base64.b64encode(
+                    "{}:{}".format(api_key.id, api_key.secret).encode('utf-8'))
+        }
+        body = {'grant_type': 'client_credentials', 'scope': 's1'}
+
+        result = self.app.authenticate_api(
+            allowed_scopes=['s1'], http_method='GET', uri='some@uri.com',
+            body=body, headers=headers)
+
+        self.assertEqual(api_key.id, result.api_key.id)
+        self.assertEqual(api_key.secret, result.api_key.secret)
+        self.assertEqual(acc.href, result.api_key.account.href)
+        self.assertEqual(result.token.scopes, ['s1'])
+
+        headers = {
+            'Authorization': b'Bearer ' + result.token.token.encode('utf-8')}
+
+        result = self.app.authenticate_api(
+            allowed_scopes=['s1', 's2'], http_method='GET', uri='some@uri.com',
+            body={}, headers=headers)
+
+        self.assertIsNone(result)

--- a/tests/live/test_api_auth.py
+++ b/tests/live/test_api_auth.py
@@ -1,5 +1,6 @@
 """Live tests of client authentication against the Stormpath service API."""
 import base64
+from six import u
 
 from .base import ApiKeyBase
 
@@ -33,7 +34,7 @@ class TestApiAuth(ApiKeyBase):
             '{}:{}'.format(api_key.id, api_key.secret).encode('utf-8'))
         headers = {
             'Authorization':
-                'Basic ' + b64_key.decode('utf-8')
+                u('Basic ') + b64_key.decode('utf-8')
         }
 
         result = self.app.authenticate_api(
@@ -99,7 +100,7 @@ class TestApiAuth(ApiKeyBase):
         b64_key = base64.b64encode(
             '{}:{}'.format(api_key.id, api_key.secret).encode('utf-8'))
         headers = {
-            'Authorization': 'Basic ' + b64_key.decode('utf-8')
+            'Authorization': u('Basic ') + b64_key.decode('utf-8')
         }
         body = {'grant_type': 'client_credentials', 'scope': 's1 s2'}
         scopes = ['s1', 's2']
@@ -114,7 +115,7 @@ class TestApiAuth(ApiKeyBase):
         self.assertEqual(result.token.scopes, scopes)
 
         headers = {
-            'Authorization': 'Bearer ' + result.token.token}
+            'Authorization': u('Bearer ') + result.token.token}
 
         result = self.app.authenticate_api(
             allowed_scopes=scopes, http_method='GET', uri='some@uri.com',

--- a/tests/live/test_appdir.py
+++ b/tests/live/test_appdir.py
@@ -2,7 +2,7 @@
 
 from stormpath.error import Error
 
-from .base import AuthenticatedLiveBase, SingleApplicationBase
+from .base import AuthenticatedLiveBase, SingleApplicationBase, AccountBase
 
 
 class TestApplicationDirectoryCreation(AuthenticatedLiveBase):
@@ -178,3 +178,11 @@ class TestApplicationDirectoryModification(SingleApplicationBase):
 
         self.assertEqual(len(dirs), 1)
         self.assertEqual(dirs[0].href, self.dir.href)
+
+
+class TestApplicationVerificationEmail(AccountBase):
+
+    def test_resend_fails_for_directory_with_disabled_verificiation(self):
+        name, acc = self.create_account(self.app.accounts)
+        with self.assertRaises(Error):
+            self.app.verification_emails.resend(acc, self.dir)

--- a/tests/live/test_resource.py
+++ b/tests/live/test_resource.py
@@ -3,6 +3,7 @@
 We can use (almost) any resource here - Account is a convenient choice.
 """
 import jwt
+from stormpath.cache.entry import CacheEntry
 from stormpath.resources.base import Expansion
 
 from .base import AccountBase
@@ -46,6 +47,19 @@ class TestResource(AccountBase):
 
         self.assertFalse(acc.is_enabled())
         self.assertTrue(acc.is_disabled())
+
+    def test_cache_entry_to_dict_parse(self):
+        _, acc = self.create_account(self.app.accounts)
+        acc.update({'surname': 'Surname'})
+
+        acc_entry_before = acc._store._get_cache(acc.href).store[acc.href]
+        acc_entry_after = CacheEntry.parse(acc_entry_before.to_dict())
+        self.assertEqual(acc_entry_before.value, acc_entry_after.value)
+        self.assertEqual(
+            acc_entry_before.created_at, acc_entry_after.created_at)
+        self.assertEqual(
+            acc_entry_before.last_accessed_at,
+            acc_entry_after.last_accessed_at)
 
 
 class TestCollectionResource(AccountBase):

--- a/tests/mocks/test_api_auth.py
+++ b/tests/mocks/test_api_auth.py
@@ -20,7 +20,7 @@ class ApiAuthTest(TestCase):
     def test_basic_api_auth(self):
         app = MagicMock()
         app._client.auth.secret = 'fakeApiKeyProperties.secret'
-        app.href = b'HREF'
+        app.href = 'HREF'
         api_keys = MagicMock()
         api_keys.get_key = lambda k, s=None: MagicMock(
                 id=FAKE_CLIENT_ID, secret=FAKE_CLIENT_SECRET, status=StatusMixin.STATUS_ENABLED)
@@ -42,10 +42,34 @@ class ApiAuthTest(TestCase):
         self.assertIsNone(result.token)
         self.assertIsNotNone(result.api_key)
 
+    def test_basic_api_auth_unicode(self):
+        app = MagicMock()
+        app._client.auth.secret = 'fakeApiKeyProperties.secret'
+        app.href = 'HREF'
+        api_keys = MagicMock()
+        api_keys.get_key = lambda k, s=None: MagicMock(
+                id=FAKE_CLIENT_ID, secret=FAKE_CLIENT_SECRET, status=StatusMixin.STATUS_ENABLED)
+        app.api_keys = api_keys
+
+        basic_auth = base64.b64encode(
+            "{}:{}".format(FAKE_CLIENT_ID, FAKE_CLIENT_SECRET).encode('utf-8'))
+
+        uri = 'https://example.com/get'
+        http_method = 'GET'
+        body = {}
+        headers = {'Authorization': u'Basic ' + basic_auth.decode('utf-8')}
+
+        allowed_scopes = ['test1']
+
+        result = authenticate(app, allowed_scopes, http_method, uri, body, headers)
+        self.assertIsNotNone(result)
+        self.assertIsNone(result.token)
+        self.assertIsNotNone(result.api_key)
+
     def test_basic_api_auth_with_generating_bearer_token(self):
         app = MagicMock()
         app._client.auth.secret = 'fakeApiKeyProperties.secret'
-        app.href = b'HREF'
+        app.href = 'HREF'
         api_keys = MagicMock()
         api_keys.get_key = lambda k, s=None: MagicMock(
                 id=FAKE_CLIENT_ID, secret=FAKE_CLIENT_SECRET, status=StatusMixin.STATUS_ENABLED)
@@ -71,7 +95,7 @@ class ApiAuthTest(TestCase):
     def test_basic_api_auth_with_invalid_scope_no_token_get_generated(self):
         app = MagicMock()
         app._client.auth.secret = 'fakeApiKeyProperties.secret'
-        app.href = b'HREF'
+        app.href = 'HREF'
         api_keys = MagicMock()
         api_keys.get_key = lambda k, s=None: MagicMock(
                 id=FAKE_CLIENT_ID, secret=FAKE_CLIENT_SECRET, status=StatusMixin.STATUS_ENABLED)
@@ -95,7 +119,7 @@ class ApiAuthTest(TestCase):
     def test_basic_api_auth_invalid_credentials(self):
         app = MagicMock()
         app._client.auth.secret = 'fakeApiKeyProperties.secret'
-        app.href = b'HREF'
+        app.href = 'HREF'
         api_keys = MagicMock()
         api_keys.get_key = lambda k, s=None: None
 
@@ -119,7 +143,7 @@ class ApiAuthTest(TestCase):
     def test_bearer_api_auth(self):
         app = MagicMock()
         app._client.auth.secret = 'fakeApiKeyProperties.secret'
-        app.href = b'HREF'
+        app.href = 'HREF'
         api_keys = MagicMock()
         api_keys.get_key = lambda k, s=None: MagicMock(
                 id=FAKE_CLIENT_ID, secret=FAKE_CLIENT_SECRET, status=StatusMixin.STATUS_ENABLED)
@@ -147,12 +171,44 @@ class ApiAuthTest(TestCase):
 
         result = authenticate(app, allowed_scopes, http_method, uri, body, headers)
         self.assertIsNotNone(result)
-        self.assertEquals(result.token.token.decode('utf-8'), token.token)
+        self.assertEquals(result.token.token, token.token)
+
+    def test_bearer_api_auth_with_unicode(self):
+        app = MagicMock()
+        app._client.auth.secret = 'fakeApiKeyProperties.secret'
+        app.href = 'HREF'
+        api_keys = MagicMock()
+        api_keys.get_key = lambda k, s=None: MagicMock(
+                id=FAKE_CLIENT_ID, secret=FAKE_CLIENT_SECRET, status=StatusMixin.STATUS_ENABLED)
+        app.api_keys = api_keys
+
+        basic_auth = base64.b64encode(
+            "{}:{}".format(FAKE_CLIENT_ID, FAKE_CLIENT_SECRET).encode('utf-8'))
+
+        uri = 'https://example.com/get'
+        http_method = 'GET'
+        body = {'grant_type': 'client_credentials', 'scope': 'test1'}
+        headers = {'Authorization': u'Basic ' + basic_auth.decode('utf-8')}
+
+        allowed_scopes = ['test1']
+
+        result = authenticate(app, allowed_scopes, http_method, uri, body, headers)
+        self.assertIsNotNone(result)
+        self.assertIsNotNone(result.token)
+        token = result.token
+        body = {}
+        headers = {
+                'Authorization': b'Bearer ' + token.token.encode('utf-8')
+                }
+
+        result = authenticate(app, allowed_scopes, http_method, uri, body, headers)
+        self.assertIsNotNone(result)
+        self.assertEquals(result.token.token, token.token)
 
     def test_access_token_validity_expired_token(self):
         app = MagicMock()
         app._client.auth.secret = 'fakeApiKeyProperties.secret'
-        app.href = b'HREF'
+        app.href = 'HREF'
         api_keys = MagicMock()
         api_keys.get_key = lambda k, s=None: MagicMock(
                 id=FAKE_CLIENT_ID, secret=FAKE_CLIENT_SECRET, status=StatusMixin.STATUS_ENABLED)
@@ -168,7 +224,7 @@ class ApiAuthTest(TestCase):
     def test_access_token_scope_check(self):
         app = MagicMock()
         app._client.auth.secret = 'fakeApiKeyProperties.secret'
-        app.href = b'HREF'
+        app.href = 'HREF'
         api_keys = MagicMock()
         api_keys.get_key = lambda k, s=None: MagicMock(
                 id=FAKE_CLIENT_ID, secret=FAKE_CLIENT_SECRET, status=StatusMixin.STATUS_ENABLED)
@@ -183,7 +239,7 @@ class ApiAuthTest(TestCase):
     def test_access_token_invalid_token(self):
         app = MagicMock()
         app._client.auth.secret = 'fakeApiKeyProperties.secret'
-        app.href = b'HREF'
+        app.href = 'HREF'
         api_keys = MagicMock()
         api_keys.get_key = lambda k, s=None: MagicMock(
                 id=FAKE_CLIENT_ID, secret=FAKE_CLIENT_SECRET, status=StatusMixin.STATUS_ENABLED)
@@ -199,7 +255,7 @@ class ApiAuthTest(TestCase):
     def test_valid_bearer_token_but_deleted_api_key(self):
         app = MagicMock()
         app._client.auth.secret = 'fakeApiKeyProperties.secret'
-        app.href = b'HREF'
+        app.href = 'HREF'
         api_keys = MagicMock()
         api_keys.get_key = lambda k, s=None: MagicMock(
                 id=FAKE_CLIENT_ID, secret=FAKE_CLIENT_SECRET, status=StatusMixin.STATUS_ENABLED)
@@ -233,7 +289,7 @@ class ApiAuthTest(TestCase):
     def test_valid_bearer_token_but_disabled_api_key(self):
         app = MagicMock()
         app._client.auth.secret = 'fakeApiKeyProperties.secret'
-        app.href = b'HREF'
+        app.href = 'HREF'
         api_keys = MagicMock()
         api_keys.get_key = lambda k, s=None: MagicMock(
                 id=FAKE_CLIENT_ID, secret=FAKE_CLIENT_SECRET, status=StatusMixin.STATUS_ENABLED)
@@ -271,7 +327,7 @@ class ApiAuthTest(TestCase):
     def test_invalid_grant_type_no_token_gets_generated(self):
         app = MagicMock()
         app._client.auth.secret = 'fakeApiKeyProperties.secret'
-        app.href = b'HREF'
+        app.href = 'HREF'
         api_keys = MagicMock()
         api_keys.get_key = lambda k, s=None: MagicMock(
                 id=FAKE_CLIENT_ID, secret=FAKE_CLIENT_SECRET, status=StatusMixin.STATUS_ENABLED)

--- a/tests/mocks/test_api_auth.py
+++ b/tests/mocks/test_api_auth.py
@@ -1,7 +1,7 @@
 import base64
 
 from unittest import TestCase, main
-from stormpath.client import Client
+from six import u
 try:
     from mock import patch, MagicMock, PropertyMock
 except ImportError:
@@ -57,7 +57,7 @@ class ApiAuthTest(TestCase):
         uri = 'https://example.com/get'
         http_method = 'GET'
         body = {}
-        headers = {'Authorization': u'Basic ' + basic_auth.decode('utf-8')}
+        headers = {'Authorization': u('Basic ') + basic_auth.decode('utf-8')}
 
         allowed_scopes = ['test1']
 
@@ -188,7 +188,7 @@ class ApiAuthTest(TestCase):
         uri = 'https://example.com/get'
         http_method = 'GET'
         body = {'grant_type': 'client_credentials', 'scope': 'test1'}
-        headers = {'Authorization': u'Basic ' + basic_auth.decode('utf-8')}
+        headers = {'Authorization': u('Basic ') + basic_auth.decode('utf-8')}
 
         allowed_scopes = ['test1']
 

--- a/tests/mocks/test_http.py
+++ b/tests/mocks/test_http.py
@@ -9,7 +9,7 @@ from stormpath.client import Client
 try:
     from mock import patch, MagicMock, PropertyMock, call
 except ImportError:
-    from unittest.mock import patch, MagicMock, PropertyMock
+    from unittest.mock import patch, MagicMock, PropertyMock, call
 
 
 class HttpTest(TestCase):

--- a/tests/mocks/test_verification_email.py
+++ b/tests/mocks/test_verification_email.py
@@ -1,0 +1,42 @@
+""""
+Integration tests for various pieces involved in external provider support.
+"""
+
+from unittest import TestCase, main
+
+try:
+    from mock import MagicMock
+except ImportError:
+    from unittest.mock import MagicMock
+
+from stormpath.resources.account import Account
+from stormpath.resources.application import Application
+from stormpath.resources.directory import Directory, DirectoryList
+from stormpath.resources.verification_email import VerificationEmailList
+
+
+class TestVerificationEmail(TestCase):
+
+    def test_resend(self):
+        ds = MagicMock()
+        ds.create_resource.return_value = {}
+        client = MagicMock(data_store=ds, BASE_URL='http://example.com/')
+
+        acc = Account(
+            client=client,
+            properties={'href': 'test/app','email': 'some@email.com'})
+        vel = VerificationEmailList(client=client, href='test/emails')
+        app = Application(
+            client=client,
+            properties={'href': 'test/app','verification_emails': vel})
+        dir = Directory(client=client, href='test/directory')
+
+        app.verification_emails.resend(acc, dir)
+
+        ds.create_resource.assert_called_once_with(
+            'http://example.com/test/emails',
+            {'login': 'some@email.com', 'account_store': 'test/directory'})
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I added some tests to improve test coverage and along the way found bug in API authentication when using Python 3. This PR also contains fix for that bug (commit 2dc1ca78e6a51bee889176b3a4e993eceaadaabc).