### PR TITLE
Account authentication

### DIFF
--- a/stormpath/api_auth.py
+++ b/stormpath/api_auth.py
@@ -202,7 +202,15 @@ def _authenticate_request(app, allowed_scopes, http_method, uri, body, headers, 
     return None, None
 
 
-def authenticate(app, allowed_scopes, http_method, uri, body, headers, ttl=DEFAULT_TTL):
+def authenticate(app=None, allowed_scopes=None, http_method='', uri='',
+                 body=None, headers=None, ttl=DEFAULT_TTL):
+    if body is None:
+        raise ValueError("body can't be None")
+    if headers is None:
+        raise ValueError("headers can't be None")
+    if allowed_scopes is None:
+        allowed_scopes = []
+
     for k, v in headers.items():
         headers[k] = to_unicode(v, 'ascii')
     jwt_token = None

--- a/stormpath/api_auth.py
+++ b/stormpath/api_auth.py
@@ -8,6 +8,9 @@ from oauthlib.oauth2 import BackendApplicationServer as Oauth2BackendApplication
 from oauthlib.oauth2 import BackendApplicationClient as Oauth2BackendApplicationClient
 from oauthlib.common import to_unicode
 
+from stormpath.error import Error as StormpathError
+
+
 GRANT_TYPE_CLIENT_CREDENTIALS = 'client_credentials'
 GRANT_TYPES = [GRANT_TYPE_CLIENT_CREDENTIALS]
 DEFAULT_TTL = 3600
@@ -16,6 +19,7 @@ DEFAULT_TTL = 3600
 class DummyRequest(object):
     """Used to model the same flow for Basic and Bearer"""
     def __init__(self, api_key):
+        self.account = None
         self.api_key = api_key
 
 
@@ -45,12 +49,26 @@ class AccessToken(object):
         self.token = token
         self.app = app
         self.token_scopes = []
+        self.account = None
         self.api_key = None
+        self.for_api_key = True
 
         # get raw data without validation
         try:
             data = jwt.decode(self.token, verify=False)
             self.client_id = data.get('sub', '')
+            try:
+                self.account = self.app.accounts.get(data.get('sub', ''))
+
+                # We're accessing account.username here to force
+                # evaluation of this Account -- this allows us to check
+                # and see whether or not this Account is actually
+                # valid.
+                self.account.username
+            except StormpathError:
+                self.account = None
+            if self.account:
+                self.for_api_key = False
             self.api_key = self.app.api_keys.get_key(self.client_id)
             self.exp = data.get('exp', 0)
             self.scopes = data.get('scope', '').split(' ')
@@ -61,8 +79,14 @@ class AccessToken(object):
         return self.token
 
     def _is_valid(self):
-        if ((self.api_key and self.api_key.is_enabled()) and
-                 datetime.datetime.utcnow() < datetime.datetime.utcfromtimestamp(float(self.exp))):
+        if self.for_api_key:
+            valid = self.api_key and self.api_key.is_enabled()
+        else:
+            valid = bool(self.account)
+
+        if valid and \
+                datetime.datetime.utcnow() < \
+                    datetime.datetime.utcfromtimestamp(float(self.exp)):
 
             try:
                 jwt.decode(self.token, self.app._client.auth.secret)
@@ -83,10 +107,10 @@ class AccessToken(object):
 
 
 class ApiAuthenticationResult(object):
-    def __init__(self, api_key, access_token):
+    def __init__(self, account, api_key, access_token):
         self.api_key = api_key
         self.token = access_token
-        self.account = self.api_key.account
+        self.account = self.api_key.account if self.api_key else account
 
 
 class SPOauth2RequestValidator(Oauth2RequestValidator):
@@ -139,6 +163,7 @@ class SPOauth2RequestValidator(Oauth2RequestValidator):
     def validate_bearer_token(self, token, scopes, request):
         # Remember to check expiration and scope membership
         access_token = AccessToken(self.app, token)
+        request.account = access_token.account
         request.api_key = access_token.api_key
         if access_token._is_valid() and access_token._within_scope(scopes):
             return True
@@ -227,5 +252,6 @@ def authenticate(app=None, allowed_scopes=None, http_method='', uri='',
     valid, r = _authenticate_request(app, allowed_scopes, http_method, uri, body, headers, ttl=ttl)
     if not valid:
         return None
-    return ApiAuthenticationResult(api_key=r.api_key, access_token=access_token)
+    return ApiAuthenticationResult(
+        account=r.account, api_key=r.api_key, access_token=access_token)
 

--- a/stormpath/resources/application.py
+++ b/stormpath/resources/application.py
@@ -155,7 +155,8 @@ class Application(Resource, DeleteMixin, DictMixin, AutoSaveMixin, SaveMixin, St
         data = {'password': password}
         self._store.create_resource(href=href, data=data)
 
-    def authenticate_api(self, allowed_scopes, http_method, uri, body, headers, **kwargs):
+    def authenticate_api(self, allowed_scopes=None, http_method='', uri='',
+                         body=None, headers=None, **kwargs):
         from ..api_auth import authenticate
 
         return authenticate(self, allowed_scopes, http_method, uri, body, headers, **kwargs)

--- a/stormpath/resources/application.py
+++ b/stormpath/resources/application.py
@@ -156,10 +156,12 @@ class Application(Resource, DeleteMixin, DictMixin, AutoSaveMixin, SaveMixin, St
         self._store.create_resource(href=href, data=data)
 
     def authenticate_api(self, allowed_scopes=None, http_method='', uri='',
-                         body=None, headers=None, **kwargs):
+                         body=None, headers=None, locations=None, **kwargs):
         from ..api_auth import authenticate
 
-        return authenticate(self, allowed_scopes, http_method, uri, body, headers, **kwargs)
+        return authenticate(
+            app=self, allowed_scopes=allowed_scopes, http_method=http_method,
+            uri=uri, body=body, headers=headers, locations=locations, **kwargs)
 
     def build_id_site_redirect_url(self, callback_uri, path=None, state=None, logout=False):
         """Builds a redirect uri for ID site.

--- a/stormpath/resources/application.py
+++ b/stormpath/resources/application.py
@@ -85,8 +85,8 @@ class Application(Resource, DeleteMixin, DictMixin, AutoSaveMixin, SaveMixin, St
             A specific :class:`stormpath.resources.account_store.AccountStore`
             object to authenticate against (optional)
         """
-        return self.login_attempts.basic_auth(login, password, expand,
-            account_store)
+        return self.login_attempts.basic_auth(
+            login, password, expand, account_store, app=self)
 
     def get_provider_account(self, provider, **provider_kwargs):
         """Used for getting account data from 3rd party Providers

--- a/stormpath/resources/login_attempt.py
+++ b/stormpath/resources/login_attempt.py
@@ -1,7 +1,12 @@
 """Stormpath LoginAttempt resource mappings."""
 
 
+import datetime
+import jwt
 from base64 import b64encode
+from oauthlib.common import to_unicode
+from stormpath.api_auth import AccessToken
+from uuid import uuid4
 
 from .base import (
     CollectionResource,
@@ -16,7 +21,7 @@ class AuthenticationResult(Resource):
     http://docs.stormpath.com/rest/product-guide/#authenticate-an-account
     """
 
-    writable_attrs = ('type', 'value', 'account_store')
+    writable_attrs = ('type', 'value', 'account_store', 'application')
 
     @staticmethod
     def get_resource_attributes():
@@ -30,12 +35,50 @@ class AuthenticationResult(Resource):
         return '<%s attributes=%s>' % (self.__class__.__name__,
             str(self._get_property_names()))
 
+    def get_jwt(self):
+        if not hasattr(self, 'application'):
+            raise ValueError('JWT cannot be generated without application')
+
+        secret = self.application._client.auth.secret
+        now = datetime.datetime.utcnow()
+
+        try:
+            jti = uuid4().get_hex()
+        except AttributeError:
+            jti = uuid4().hex
+
+        data = {
+            'iss': self.application.href,
+            'sub': self.account.href,
+            'jti': jti,
+            'exp': now + datetime.timedelta(seconds=3600)
+        }
+
+        token = jwt.encode(data, secret, 'HS256')
+        token = to_unicode(token, 'UTF-8')
+
+        return token
+
+    def get_access_token(self, jwt=None):
+        if not hasattr(self, 'application'):
+            raise ValueError(
+                'Access token cannot be generated without application')
+
+        if jwt is None:
+            jwt = self.get_jwt()
+
+        return AccessToken(self.application, jwt)
+
+    def get_access_token_response(self, jwt=None):
+        return self.get_access_token(jwt).to_json()
+
 
 class LoginAttemptList(CollectionResource):
     """List of login data."""
     resource_class = AuthenticationResult
 
-    def basic_auth(self, login, password, expand, account_store=None):
+    def basic_auth(self, login, password, expand, account_store=None,
+                   app=None):
         value = login + ':' + password
         value = b64encode(value.encode('utf-8')).decode('ascii')
         properties = {
@@ -46,4 +89,9 @@ class LoginAttemptList(CollectionResource):
         if account_store:
             properties['account_store'] = account_store
 
-        return self.create(properties, expand=expand)
+        result = self.create(properties, expand=expand)
+
+        if app:
+            result.application = app
+
+        return result

--- a/tests/live/test_api_auth.py
+++ b/tests/live/test_api_auth.py
@@ -17,9 +17,7 @@ class TestApiAuth(ApiKeyBase):
                     "{}:{}".format(api_key.id, api_key.secret).encode('utf-8'))
         }
 
-        result = self.app.authenticate_api(
-            allowed_scopes=[], http_method='GET', uri='some@uri.com', body={},
-            headers=headers)
+        result = self.app.authenticate_api(body={}, headers=headers)
 
         self.assertIsNotNone(result)
         self.assertEqual(api_key.id, result.api_key.id)
@@ -37,9 +35,7 @@ class TestApiAuth(ApiKeyBase):
                 u('Basic ') + b64_key.decode('utf-8')
         }
 
-        result = self.app.authenticate_api(
-            allowed_scopes=[], http_method='GET', uri='some@uri.com', body={},
-            headers=headers)
+        result = self.app.authenticate_api(body={}, headers=headers)
 
         self.assertIsNotNone(result)
         self.assertEqual(api_key.id, result.api_key.id)
@@ -56,9 +52,7 @@ class TestApiAuth(ApiKeyBase):
                     "{}:{}".format(api_key.id, 'INVALID').encode('utf-8'))
         }
 
-        result = self.app.authenticate_api(
-            allowed_scopes=[], http_method='GET', uri='some@uri.com', body={},
-            headers=headers)
+        result = self.app.authenticate_api(body={}, headers=headers)
 
         self.assertIsNone(result)
 
@@ -75,8 +69,7 @@ class TestApiAuth(ApiKeyBase):
         scopes = ['s1', 's2']
 
         result = self.app.authenticate_api(
-            allowed_scopes=scopes, http_method='GET', uri='some@uri.com',
-            body=body, headers=headers)
+            allowed_scopes=scopes, body=body, headers=headers)
 
         self.assertEqual(api_key.id, result.api_key.id)
         self.assertEqual(api_key.secret, result.api_key.secret)
@@ -87,8 +80,7 @@ class TestApiAuth(ApiKeyBase):
             'Authorization': b'Bearer ' + result.token.token.encode('utf-8')}
 
         result = self.app.authenticate_api(
-            allowed_scopes=scopes, http_method='GET', uri='some@uri.com',
-            body={}, headers=headers)
+            allowed_scopes=scopes, body={}, headers=headers)
 
         self.assertIsNotNone(result)
         self.assertEqual(acc.href, result.account.href)
@@ -106,8 +98,7 @@ class TestApiAuth(ApiKeyBase):
         scopes = ['s1', 's2']
 
         result = self.app.authenticate_api(
-            allowed_scopes=scopes, http_method='GET', uri='some@uri.com',
-            body=body, headers=headers)
+            allowed_scopes=scopes, body=body, headers=headers)
 
         self.assertEqual(api_key.id, result.api_key.id)
         self.assertEqual(api_key.secret, result.api_key.secret)
@@ -118,8 +109,7 @@ class TestApiAuth(ApiKeyBase):
             'Authorization': u('Bearer ') + result.token.token}
 
         result = self.app.authenticate_api(
-            allowed_scopes=scopes, http_method='GET', uri='some@uri.com',
-            body={}, headers=headers)
+            allowed_scopes=scopes, body={}, headers=headers)
 
         self.assertIsNotNone(result)
         self.assertEqual(acc.href, result.account.href)
@@ -128,8 +118,7 @@ class TestApiAuth(ApiKeyBase):
         headers = {'Authorization': b'Bearer INVALID_TOKEN'}
 
         result = self.app.authenticate_api(
-            allowed_scopes=[], http_method='GET', uri='some@uri.com',
-            body={}, headers=headers)
+            allowed_scopes=[], body={}, headers=headers)
 
         self.assertIsNone(result)
 
@@ -145,8 +134,7 @@ class TestApiAuth(ApiKeyBase):
         body = {'grant_type': 'client_credentials', 'scope': 's1'}
 
         result = self.app.authenticate_api(
-            allowed_scopes=['s1'], http_method='GET', uri='some@uri.com',
-            body=body, headers=headers)
+            allowed_scopes=['s1'], body=body, headers=headers)
 
         self.assertEqual(api_key.id, result.api_key.id)
         self.assertEqual(api_key.secret, result.api_key.secret)
@@ -157,7 +145,6 @@ class TestApiAuth(ApiKeyBase):
             'Authorization': b'Bearer ' + result.token.token.encode('utf-8')}
 
         result = self.app.authenticate_api(
-            allowed_scopes=['s1', 's2'], http_method='GET', uri='some@uri.com',
-            body={}, headers=headers)
+            allowed_scopes=['s1', 's2'], body={}, headers=headers)
 
         self.assertIsNone(result)

--- a/tests/live/test_api_auth.py
+++ b/tests/live/test_api_auth.py
@@ -3,6 +3,7 @@ import base64
 from six import u
 
 from .base import ApiKeyBase
+from stormpath.error import Error as StormpathError
 
 
 class TestApiAuth(ApiKeyBase):
@@ -147,4 +148,124 @@ class TestApiAuth(ApiKeyBase):
         result = self.app.authenticate_api(
             allowed_scopes=['s1', 's2'], body={}, headers=headers)
 
+        self.assertIsNone(result)
+
+    def test_valid_bearer_token_but_deleted_api_key(self):
+        _, acc = self.create_account(self.app.accounts)
+        api_key = self.create_api_key(acc)
+
+        basic_auth = base64.b64encode(
+            "{}:{}".format(api_key.id, api_key.secret).encode('utf-8'))
+
+        body = {'grant_type': 'client_credentials', 'scope': 'test1'}
+        headers = {
+                'Authorization': b'Basic ' + basic_auth
+                }
+
+        allowed_scopes = ['test1']
+
+        result = self.app.authenticate_api(
+            allowed_scopes=allowed_scopes, body=body, headers=headers)
+        self.assertIsNotNone(result)
+        self.assertIsNotNone(result.token)
+        token = result.token
+        body = {}
+        headers = {
+                'Authorization': b'Bearer ' + token.token.encode('utf-8')
+                }
+
+        api_key.delete()
+
+        result = self.app.authenticate_api(
+            allowed_scopes=allowed_scopes, body=body, headers=headers)
+        self.assertIsNone(result)
+
+    def test_valid_bearer_token_but_disabled_api_key(self):
+        _, acc = self.create_account(self.app.accounts)
+        api_key = self.create_api_key(acc)
+
+        basic_auth = base64.b64encode(
+            "{}:{}".format(api_key.id, api_key.secret).encode('utf-8'))
+
+        body = {'grant_type': 'client_credentials', 'scope': 'test1'}
+        headers = {
+                'Authorization': b'Basic ' + basic_auth
+                }
+
+        allowed_scopes = ['test1']
+
+        result = self.app.authenticate_api(
+            allowed_scopes=allowed_scopes, body=body, headers=headers)
+        self.assertIsNotNone(result)
+        self.assertIsNotNone(result.token)
+        token = result.token
+        body = {}
+        headers = {
+                'Authorization': b'Bearer ' + token.token.encode('utf-8')
+                }
+
+        api_key.status = 'disabled'
+        api_key.save()
+
+        result = self.app.authenticate_api(
+            allowed_scopes=allowed_scopes, body=body, headers=headers)
+        self.assertIsNone(result)
+
+    def test_invalid_grant_type_no_token_gets_generated(self):
+        _, acc = self.create_account(self.app.accounts)
+        api_key = self.create_api_key(acc)
+
+        basic_auth = base64.b64encode(
+            "{}:{}".format(api_key.id, api_key.secret).encode('utf-8'))
+
+        body = {'grant_type': 'invalid_grant', 'scope': 'test1'}
+        headers = {
+                'Authorization': b'Basic ' + basic_auth
+                }
+
+        allowed_scopes = ['test1']
+
+        result = self.app.authenticate_api(
+            allowed_scopes=allowed_scopes, body=body, headers=headers)
+        self.assertIsNotNone(result)
+        self.assertIsNone(result.token)
+
+    def test_account_authentication_successfull(self):
+        _, acc = self.create_account(self.app.accounts)
+        pwd = 'Pwd123456789'
+        acc.password = pwd
+        acc.save()
+
+        auth_result = self.app.authenticate_account(acc.username, pwd)
+        at = auth_result.get_access_token()
+
+        headers = {
+            'Authorization': b'Bearer ' + at.token.encode('utf-8')}
+
+        result = self.app.authenticate_api(body={}, headers=headers)
+        self.assertIsNotNone(result)
+
+    def test_account_authentication_invalid_credentials(self):
+        _, acc = self.create_account(self.app.accounts)
+        pwd = 'Pwd123456789'
+        acc.password = pwd
+        acc.save()
+
+        with self.assertRaises(StormpathError):
+            self.app.authenticate_account(acc.username, 'invalid')
+
+    def test_account_authentication_invalid_access_token(self):
+        _, acc = self.create_account(self.app.accounts)
+        pwd = 'Pwd123456789'
+        acc.password = pwd
+        acc.save()
+
+        auth_result = self.app.authenticate_account(acc.username, pwd)
+        at = auth_result.get_access_token()
+        at.token = 'invalid'
+
+        headers = {
+            'Authorization': b'Bearer ' + at.token.encode('utf-8')}
+
+        result = self.app.authenticate_api(body={}, headers=headers)
         self.assertIsNone(result)

--- a/tests/mocks/test_account.py
+++ b/tests/mocks/test_account.py
@@ -1,15 +1,14 @@
-import base64
-
 from unittest import TestCase, main
-from stormpath.client import Client
+
 try:
     from mock import patch, MagicMock, PropertyMock, create_autospec
 except ImportError:
     from unittest.mock import patch, MagicMock, PropertyMock, create_autospec
 
 from stormpath.resources.account import Account
-from stormpath.resources.group import Group, GroupList
 from stormpath.resources.directory import Directory
+from stormpath.resources.group import Group, GroupList
+from stormpath.resources.login_attempt import AuthenticationResult
 
 
 class TestAccount(TestCase):
@@ -109,6 +108,21 @@ class TestAccount(TestCase):
         d._set_properties({'groups': gs})
         self.account._set_properties({'directory': d, 'groups': gs})
         self.assertTrue(self.account.has_group('group'))
+
+    def test_login_attempt(self):
+        app = MagicMock()
+        app.accounts.get.return_value = self.account
+        app._client.auth.secret = 'fakeApiKeyProperties.secret'
+        app.href = 'http://example.com/application'
+
+        ar = AuthenticationResult(
+            client=self.client,
+            properties={'account': self.account, 'application': app})
+        at = ar.get_access_token()
+
+        self.assertEqual(self.account, at.account)
+        self.assertEqual(app, at.app)
+        self.assertFalse(at.for_api_key)
 
 
 if __name__ == '__main__':

--- a/tests/mocks/test_api_auth.py
+++ b/tests/mocks/test_api_auth.py
@@ -43,7 +43,7 @@ class ApiAuthTest(TestCase):
         self.assertIsNone(result.token)
         self.assertIsNotNone(result.api_key)
 
-    def test_basic_api_auth_unicode(self):
+    def test_basic_api_auth_unicode_and_locations(self):
         app = MagicMock()
         app._client.auth.secret = 'fakeApiKeyProperties.secret'
         app.href = 'HREF'
@@ -62,7 +62,8 @@ class ApiAuthTest(TestCase):
 
         allowed_scopes = ['test1']
 
-        result = authenticate(app, allowed_scopes, http_method, uri, body, headers)
+        result = authenticate(
+            app, allowed_scopes, http_method, uri, body, headers, ['header'])
         self.assertIsNotNone(result)
         self.assertIsNone(result.token)
         self.assertIsNotNone(result.api_key)
@@ -203,6 +204,130 @@ class ApiAuthTest(TestCase):
                 }
 
         result = authenticate(app, allowed_scopes, http_method, uri, body, headers)
+        self.assertIsNotNone(result)
+        self.assertEquals(result.token.token, token.token)
+
+    def test_bearer_api_auth_with_token_in_url(self):
+        app = MagicMock()
+        app._client.auth.secret = 'fakeApiKeyProperties.secret'
+        app.href = 'HREF'
+        api_keys = MagicMock()
+        api_keys.get_key = lambda k, s=None: MagicMock(
+            id=FAKE_CLIENT_ID, secret=FAKE_CLIENT_SECRET,
+            status=StatusMixin.STATUS_ENABLED)
+        app.api_keys = api_keys
+
+        basic_auth = base64.b64encode(
+            "{}:{}".format(FAKE_CLIENT_ID, FAKE_CLIENT_SECRET).encode('utf-8'))
+
+        body = {'grant_type': 'client_credentials', 'scope': 'test1'}
+        headers = {'Authorization': b'Basic ' + basic_auth}
+
+        allowed_scopes = ['test1']
+
+        result = authenticate(
+            app=app, allowed_scopes=allowed_scopes, body=body, headers=headers)
+        self.assertIsNotNone(result)
+        self.assertIsNotNone(result.token)
+        token = result.token
+        uri = 'https://example.com/get?access_token=%s' % (token.token)
+        locations = ['url']
+
+        result = authenticate(
+            app=app, allowed_scopes=allowed_scopes, body={}, headers={},
+            uri=uri, locations=locations)
+        self.assertIsNotNone(result)
+        self.assertEquals(result.token.token, token.token)
+
+    def test_bearer_api_auth_with_token_in_url_without_locations(self):
+        app = MagicMock()
+        app._client.auth.secret = 'fakeApiKeyProperties.secret'
+        app.href = 'HREF'
+        api_keys = MagicMock()
+        api_keys.get_key = lambda k, s=None: MagicMock(
+            id=FAKE_CLIENT_ID, secret=FAKE_CLIENT_SECRET,
+            status=StatusMixin.STATUS_ENABLED)
+        app.api_keys = api_keys
+
+        basic_auth = base64.b64encode(
+            "{}:{}".format(FAKE_CLIENT_ID, FAKE_CLIENT_SECRET).encode('utf-8'))
+
+        body = {'grant_type': 'client_credentials', 'scope': 'test1'}
+        headers = {'Authorization': b'Basic ' + basic_auth}
+
+        allowed_scopes = ['test1']
+
+        result = authenticate(
+            app=app, allowed_scopes=allowed_scopes, body=body, headers=headers)
+        self.assertIsNotNone(result)
+        self.assertIsNotNone(result.token)
+        token = result.token
+        uri = 'https://example.com/get?access_token=%s' % (token.token)
+
+        result = authenticate(
+            app=app, allowed_scopes=allowed_scopes, body={}, headers={},
+            uri=uri)
+        self.assertIsNone(result)
+
+    def test_bearer_api_auth_with_token_in_body(self):
+        app = MagicMock()
+        app._client.auth.secret = 'fakeApiKeyProperties.secret'
+        app.href = 'HREF'
+        api_keys = MagicMock()
+        api_keys.get_key = lambda k, s=None: MagicMock(
+            id=FAKE_CLIENT_ID, secret=FAKE_CLIENT_SECRET,
+            status=StatusMixin.STATUS_ENABLED)
+        app.api_keys = api_keys
+
+        basic_auth = base64.b64encode(
+            "{}:{}".format(FAKE_CLIENT_ID, FAKE_CLIENT_SECRET).encode('utf-8'))
+
+        body = {'grant_type': 'client_credentials', 'scope': 'test1'}
+        headers = {'Authorization': b'Basic ' + basic_auth}
+
+        allowed_scopes = ['test1']
+
+        result = authenticate(
+            app=app, allowed_scopes=allowed_scopes, body=body, headers=headers)
+        self.assertIsNotNone(result)
+        self.assertIsNotNone(result.token)
+        token = result.token
+        body = {'access_token': token.token}
+        locations = ['body']
+
+        result = authenticate(
+            app=app, allowed_scopes=allowed_scopes, body=body, headers={},
+            locations=locations)
+        self.assertIsNotNone(result)
+        self.assertEquals(result.token.token, token.token)
+
+    def test_bearer_api_auth_with_token_in_body_without_locations(self):
+        app = MagicMock()
+        app._client.auth.secret = 'fakeApiKeyProperties.secret'
+        app.href = 'HREF'
+        api_keys = MagicMock()
+        api_keys.get_key = lambda k, s=None: MagicMock(
+            id=FAKE_CLIENT_ID, secret=FAKE_CLIENT_SECRET,
+            status=StatusMixin.STATUS_ENABLED)
+        app.api_keys = api_keys
+
+        basic_auth = base64.b64encode(
+            "{}:{}".format(FAKE_CLIENT_ID, FAKE_CLIENT_SECRET).encode('utf-8'))
+
+        body = {'grant_type': 'client_credentials', 'scope': 'test1'}
+        headers = {'Authorization': b'Basic ' + basic_auth}
+
+        allowed_scopes = ['test1']
+
+        result = authenticate(
+            app=app, allowed_scopes=allowed_scopes, body=body, headers=headers)
+        self.assertIsNotNone(result)
+        self.assertIsNotNone(result.token)
+        token = result.token
+        body = {'access_token': token.token}
+
+        result = authenticate(
+            app=app, allowed_scopes=allowed_scopes, body=body, headers={})
         self.assertIsNotNone(result)
         self.assertEquals(result.token.token, token.token)
 


### PR DESCRIPTION
This PR does three things for the API authentication:
1. It adds defaults for `allowed_scopes`, `http_method` and `uri` parameters.
2. It implements account functions for API authentication (issue #132).
3. It adds `locations` parameter to the `authenticate_api()` and `authenticate()` functions (details in commit 4b2bedd123b06e5509b0e27535eaa3896d7cff18)