### PR TITLE
Auth without scopes

### DIFF
--- a/stormpath/api_auth.py
+++ b/stormpath/api_auth.py
@@ -235,7 +235,7 @@ def _authenticate_request(auth_type, app, allowed_scopes, http_method,
 def authenticate(app=None, allowed_scopes=None, http_method='', uri='',
                  body=None, headers=None, ttl=DEFAULT_TTL, locations=None):
     if body is None:
-        raise ValueError("body can't be None")
+        body = {}
     if headers is None:
         raise ValueError("headers can't be None")
     if allowed_scopes is None:

--- a/stormpath/api_auth.py
+++ b/stormpath/api_auth.py
@@ -77,7 +77,8 @@ class AccessToken(object):
                 self.for_api_key = False
             self.api_key = self.app.api_keys.get_key(self.client_id)
             self.exp = data.get('exp', 0)
-            self.scopes = data.get('scope', '').split(' ')
+            self.scopes = data.get('scope', '') if data.get('scope') else ''
+            self.scopes = self.scopes.split(' ')
         except jwt.DecodeError:
             pass
 

--- a/tests/live/test_api_auth.py
+++ b/tests/live/test_api_auth.py
@@ -87,6 +87,31 @@ class TestApiAuth(ApiKeyBase):
         self.assertIsNotNone(result)
         self.assertEqual(acc.href, result.account.href)
 
+    def test_bearer_api_authentication_without_scopes_and_body_succeeds(self):
+        _, acc = self.create_account(self.app.accounts)
+        api_key = self.create_api_key(acc)
+
+        headers = {
+            'Authorization':
+                b'Basic ' + base64.b64encode(
+                    "{}:{}".format(api_key.id, api_key.secret).encode('utf-8'))
+        }
+        uri = 'https://example.com/get?grant_type=client_credentials'
+
+        result = self.app.authenticate_api(headers=headers, uri=uri)
+
+        self.assertEqual(api_key.id, result.api_key.id)
+        self.assertEqual(api_key.secret, result.api_key.secret)
+        self.assertEqual(acc.href, result.api_key.account.href)
+
+        headers = {
+            'Authorization': b'Bearer ' + result.token.token.encode('utf-8')}
+
+        result = self.app.authenticate_api(headers=headers)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(acc.href, result.account.href)
+
     def test_basic_api_authentication_with_grant_type_in_uri_gets_token(self):
         _, acc = self.create_account(self.app.accounts)
         api_key = self.create_api_key(acc)


### PR DESCRIPTION
This PR makes it possible to authenticate without defining scopes. Also, body is not required for authenticate() function any more, it defaults to empty dict.