### PR TITLE
Make sure that limit is not changed after iteration.

### DIFF
--- a/stormpath/resources/base.py
+++ b/stormpath/resources/base.py
@@ -380,12 +380,7 @@ class CollectionResource(Resource):
             offset += len(items)
             items = self._get_next_page(offset, limit)
 
-        # Update self._query so no more pagination is attempted.
-        if self._query is None:
-            self._query = {}
-
-        self._query['offset'] = self.__dict__['offset']
-        self._query['limit'] = self.__dict__['limit']
+        self.__dict__['limit'] = limit
 
     def __len__(self):
         self._ensure_data()

--- a/tests/live/test_resource.py
+++ b/tests/live/test_resource.py
@@ -98,6 +98,26 @@ class TestCollectionResource(AccountBase):
             {acc.href for acc in accounts}
         )
 
+    def test_limit_after_iteration(self):
+        [a.delete() for a in self.app.accounts]
+
+        for i in range(0, 120):
+            _, acc = self.create_account(self.app.accounts, given_name=str(i))
+
+        limit_before_iteration = self.app.accounts.limit
+
+        # this is done twice because we want to check that iteration
+        # works the second time, too (limit is not set to 120)
+        for i in range(0, 2):
+            iterated_accounts = []
+            for account in self.app.accounts:
+                iterated_accounts.append(int(account.given_name))
+
+            self.assertEqual(limit_before_iteration, self.app.accounts.limit)
+            self.assertEqual(len(iterated_accounts), 120)
+            self.assertEqual(
+                set(sorted(iterated_accounts)), set(range(0, 120)))
+
     def test_sorting(self):
         self.assertEqual(
             [acc.href for acc in self.app.accounts.order('email desc')],


### PR DESCRIPTION
This is fix for #154 .
The code I removed was added when collection resources where kept in object memory after iterating, so there was no point in paginating them again. Now _ensure_data() always make request, so this part has to be removed.