### PR TITLE
Sleep after resource creation to reduce test failures.

### DIFF
--- a/tests/live/base.py
+++ b/tests/live/base.py
@@ -1,10 +1,18 @@
 """Base classes for the live tests against the Stormpath API service."""
 
 from os import getenv
+from time import sleep
 from unittest import TestCase
 from uuid import uuid4
 
+from pydispatch import dispatcher
+
 from stormpath.client import Client
+from stormpath.resources.base import SIGNAL_RESOURCE_CREATED
+
+
+def sleep_receiver_function():
+    sleep(1)
 
 
 class LiveBase(TestCase):
@@ -28,6 +36,8 @@ class LiveBase(TestCase):
         if not cls.api_key_id or not cls.api_key_secret:
             raise ValueError('STORMPATH_API_KEY_ID or '
                 'STORMPATH_API_KEY_SECRET not provided')
+        dispatcher.connect(
+            sleep_receiver_function, signal=SIGNAL_RESOURCE_CREATED)
 
 
 class AuthenticatedLiveBase(LiveBase):

--- a/tests/live/base.py
+++ b/tests/live/base.py
@@ -12,6 +12,11 @@ from stormpath.resources.base import SIGNAL_RESOURCE_CREATED
 
 
 def sleep_receiver_function():
+    """Sleeps for one second.
+
+    This is used as receiver of a signal
+    (eg. when resource is created).
+    """
     sleep(1)
 
 
@@ -36,6 +41,10 @@ class LiveBase(TestCase):
         if not cls.api_key_id or not cls.api_key_secret:
             raise ValueError('STORMPATH_API_KEY_ID or '
                 'STORMPATH_API_KEY_SECRET not provided')
+
+        # This will call sleep function on every resource creation.
+        # That is done to prevent random test failures
+        # (https://github.com/stormpath/stormpath-sdk-python/issues/149).
         dispatcher.connect(
             sleep_receiver_function, signal=SIGNAL_RESOURCE_CREATED)
 


### PR DESCRIPTION
I'm not sure if this will fix #149 , but I think it is worth trying to use signals before we put sleep() after everywhere a resource is created. Also, not sure if 1 second is enough.