### PR TITLE
_ensure_data() call on dict keys

### DIFF
--- a/stormpath/resources/base.py
+++ b/stormpath/resources/base.py
@@ -312,6 +312,7 @@ class DictMixin(object):
         return hasattr(self, key)
 
     def keys(self):
+        self._ensure_data()
         return [k for k in self.__dict__.keys() if not k.startswith('_')]
 
     def values(self):
@@ -514,6 +515,9 @@ class FixedAttrsDict(DictMixin):
 
     def __dir__(self):
         return self.__dict__.keys()
+
+    def keys(self):
+        return [k for k in self.__dict__.keys() if not k.startswith('_')]
 
     def _wrap_resource_attr(self, cls, value):
         if isinstance(value, FixedAttrsDict):

--- a/tests/live/test_resource.py
+++ b/tests/live/test_resource.py
@@ -2,9 +2,12 @@
 
 We can use (almost) any resource here - Account is a convenient choice.
 """
+import datetime
 import jwt
 from time import sleep
+from uuid import uuid4
 
+from oauthlib.common import to_unicode
 from pydispatch import dispatcher
 
 from stormpath.cache.entry import CacheEntry
@@ -14,7 +17,6 @@ from stormpath.resources.base import Expansion, SIGNAL_RESOURCE_CREATED, \
 
 from .base import AccountBase, SignalReceiver
 from .base import ApiKeyBase
-
 
 
 class TestResource(AccountBase):
@@ -39,6 +41,9 @@ class TestResource(AccountBase):
         self.assertTrue('username' in acc.keys())
         self.assertTrue(acc.username in acc.values())
         self.assertTrue(('username', acc.username) in acc.items())
+
+        acc_provider_dict = dict(acc.provider_data)
+        self.assertTrue('provider_id' in acc_provider_dict)
 
     def test_status_mixin(self):
         _, acc = self.create_account(self.app.accounts)
@@ -357,11 +362,6 @@ class TestIdSite(ApiKeyBase):
         self.assertIsNone(ret.state)
 
     def test_id_site_callback_handler_account_not_in_apps_account_store(self):
-        from uuid import uuid4
-        import datetime
-        import jwt
-        from oauthlib.common import to_unicode
-
         _, acc = self.create_account(self.app.accounts)
         now = datetime.datetime.utcnow()
 

--- a/tests/live/test_resource.py
+++ b/tests/live/test_resource.py
@@ -328,11 +328,6 @@ class TestIdSite(ApiKeyBase):
 
 
     def test_id_site_callback_handler(self):
-        from uuid import uuid4
-        import datetime
-        import jwt
-        from oauthlib.common import to_unicode
-
         _, acc = self.create_account(self.app.accounts)
         now = datetime.datetime.utcnow()
 

--- a/tests/mocks/test_id_site.py
+++ b/tests/mocks/test_id_site.py
@@ -6,9 +6,9 @@ from oauthlib.common import to_unicode
 from unittest import TestCase, main
 from stormpath.client import Client
 try:
-    from mock import create_autospec, MagicMock
+    from mock import create_autospec, MagicMock, patch
 except ImportError:
-    from unittest.mock import create_autospec, MagicMock
+    from unittest.mock import create_autospec, MagicMock, patch
 
 import jwt
 
@@ -122,7 +122,11 @@ class IDSiteCallbackTest(IDSiteBuildURITest):
 
     def test_id_site_callback_handler(self):
         fake_jwt_response = 'http://localhost/?jwtResponse=%s' % self.fake_jwt
-        ret = self.app.handle_id_site_callback(fake_jwt_response)
+
+        with patch.object(Application, 'has_account') as mock_has_account:
+            mock_has_account.return_value = True
+            ret = self.app.handle_id_site_callback(fake_jwt_response)
+
         self.assertIsNotNone(ret)
         self.assertEqual(ret.account.href, self.acc.href)
         self.assertIsNone(ret.state)


### PR DESCRIPTION
DictMixin didn't call _ensure_data() before getting keys. This caused issues such as one reported in #165 .
Also, I fixed failing tests and added one to cover this bug.