### PR TITLE
Added checks for environment variables in facebook test.

### DIFF
--- a/tests/live/test_provider.py
+++ b/tests/live/test_provider.py
@@ -57,6 +57,12 @@ class TestProviderDirectories(AuthenticatedLiveBase):
         facebook_api_key_id = getenv('FACEBOOK_API_KEY_ID')
         facebook_api_key_secret = getenv('FACEBOOK_API_KEY_SECRET')
 
+        if not facebook_api_key_id:
+            self.fail("Please set FACEBOOK_API_KEY_ID environment variable!")
+        if not facebook_api_key_secret:
+            self.fail(
+                "Please set FACEBOOK_API_KEY_SECRET environment variable!")
+
         s = Session()
         res = s.request(
             'GET', 'https://graph.facebook.com/oauth/access_token',


### PR DESCRIPTION
Hey, @rdegges! develop branch has test that fails because FACEBOOK_API_KEY_ID and FACEBOOK_API_KEY_SECRET environment variables are not set. Can you please set them?
I added check for these variables, so it is clear why test is failing.