### PR TITLE
Removed support for Python 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - '2.7'
-  - '3.2'
   - '3.3'
   - '3.4'
   - pypy

--- a/README.md
+++ b/README.md
@@ -563,7 +563,7 @@ that act as a dictionary:
 The Stormpath Python SDK is well tested.  Don't take our word on it though, run
 our test suite and see for yourself!
 
-We currently test against Python 2.7, 3.2 and 3.3.
+We currently test against Python 2.7, 3.3, 3.4 and PyPy.
 
 
 ### Testing with tox

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',

--- a/tox.ini
+++ b/tox.ini
@@ -4,24 +4,10 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py32, py33, py34
+envlist = py27, py33, py34
 skipsdist=True
 
 [testenv:py27]
-usedevelop=True
-commands =
-    py.test --quiet --ignore tests/live {posargs}
-deps =
-    requests
-    pytest
-    pytest-cov
-    mock
-    oauthlib
-    PyJWT
-    python-dateutil
-    pydispatcher
-
-[testenv:py32]
 usedevelop=True
 commands =
     py.test --quiet --ignore tests/live {posargs}


### PR DESCRIPTION
pyjwt library dropped support for Python 3.2. in version 1.3: https://github.com/jpadilla/pyjwt/blob/master/CHANGELOG.md#v13
Also, this version of Python is rarely used.