### PR TITLE
Remove `Connection` header from signing process

### DIFF
--- a/stormpath/auth.py
+++ b/stormpath/auth.py
@@ -106,7 +106,11 @@ class Sauthc1Signer(AuthBase):
         # FIXME: REST API doesn't want this header in the signature.
         if 'Content-Length' in auth_headers:
             del auth_headers['Content-Length']
-
+        # Connection header can be transparently overridden by proxies anywhere and should not
+        # be a part of sig computation
+        if 'Connection' in auth_headers:
+            del auth_headers['Connection']
+            
         sorted_headers = OrderedDict(sorted(auth_headers.items()))
         canonical_headers_string = ''
         for key, value in sorted_headers.items():


### PR DESCRIPTION
Connection header should be ignored when computing as various proxies and other systems along the way could mangle that as an optimization.

Redoing PR against develop as requested