### PR TITLE
_ensure_data function shouldn't overwrite already set attrs

### DIFF
--- a/stormpath/resources/custom_data.py
+++ b/stormpath/resources/custom_data.py
@@ -114,7 +114,7 @@ class CustomData(Resource, DeleteMixin, SaveMixin):
             self.exposed_readonly_timestamp_attrs)
         return {k: self.data[k] for k in writable_attrs}
 
-    def _set_properties(self, properties):
+    def _set_properties(self, properties, overwrite=False):
         self.__dict__['data'] = self.__dict__.get('data', {})
         for k, v in properties.items():
             kcc = self.from_camel_case(k)

--- a/tests/live/test_account.py
+++ b/tests/live/test_account.py
@@ -77,6 +77,44 @@ class TestAccountCreateUpdateDelete(AccountBase):
         self.assertEqual(len(accs), 1)
         self.assertFalse(accs[0].is_enabled())
 
+    def test_account_modification_with_custom_data(self):
+        name, acc = self.create_account(self.app.accounts)
+
+        acc = self.app.accounts.get(acc.href)
+
+        acc.email = 'foo@example.com'
+        acc.status = acc.STATUS_DISABLED
+        acc.custom_data['key'] = 'value'
+        acc.save()
+
+        accs = self.app.accounts.query(email=acc.email)
+
+        self.assertEqual(len(accs), 1)
+        acc = accs[0]
+        self.assertEqual(acc.email, 'foo@example.com')
+        self.assertEqual(acc.custom_data['key'], 'value')
+        self.assertFalse(accs[0].is_enabled())
+
+    def test_account_modification_with_custom_data_and_refresh(self):
+        name, acc = self.create_account(self.app.accounts)
+        old_email = acc.email
+
+        acc = self.app.accounts.get(acc.href)
+
+        acc.email = 'foo@example.com'
+        acc.status = acc.STATUS_DISABLED
+        acc.refresh()
+        acc.custom_data['key'] = 'value'
+        acc.save()
+
+        accs = self.app.accounts.query(email=acc.email)
+
+        self.assertEqual(len(accs), 1)
+        acc = accs[0]
+        self.assertEqual(acc.email, old_email)
+        self.assertEqual(acc.custom_data['key'], 'value')
+        self.assertTrue(accs[0].is_enabled())
+
 
 class TestApplicationAuthentication(AccountBase):
 


### PR DESCRIPTION
... except refresh() function is called.

This caused problems described in issue #190.