### PR TITLE
add docs to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include README.md
 include CHANGES.md
+graft docs
+prune docs/_build
 recursive-exclude test *.py *.yml


### PR DESCRIPTION
When packaging software it is useful to optionally include the
documentation for the given release.  This ensures that the docs are
buildable from the source distribution.