### PR TITLE
add patterns to ensure tests are excluded

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
         'python-dateutil>=2.4.0',
         'pydispatcher>=2.0.5'
     ],
-    packages = find_packages(exclude=['tests']),
+    packages = find_packages(exclude=['*.tests', '*.tests.*', 'tests.*', 'tests']),
     classifiers = [
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
When doing an install with portage (which has a check for top level test
module installs), I found that tests was being installed even though it
appears to be included in the exclusion list.