### PR TITLE
name_key as acc store for LoginAttempt

### DIFF
--- a/stormpath/client.py
+++ b/stormpath/client.py
@@ -9,6 +9,8 @@ from .resources.account_store_mapping import AccountStoreMappingList
 from .resources.agent import AgentList
 from .resources.group import GroupList
 from .resources.group_membership import GroupMembershipList
+from .resources.organization import OrganizationList
+from .resources.organization_account_store_mapping import OrganizationAccountStoreMappingList
 from .resources.tenant import Tenant
 
 
@@ -94,3 +96,12 @@ class Client(object):
     @property
     def agents(self):
         return AgentList(self, href='/agents')
+
+    @property
+    def organizations(self):
+        return OrganizationList(self, href='/organizations')
+
+    @property
+    def organization_account_store_mappings(self):
+        return OrganizationAccountStoreMappingList(
+            self, href='/organizationAccountStoreMappings')

--- a/stormpath/resources/__init__.py
+++ b/stormpath/resources/__init__.py
@@ -3,6 +3,7 @@
 
 from .account import Account, AccountList
 from .account_creation_policy import AccountCreationPolicy
+from .account_store import AccountStore
 from .provider import Provider
 from .group import Group, GroupList
 from .tenant import Tenant
@@ -12,3 +13,7 @@ from .custom_data import CustomData
 from .base import (Expansion, Resource, CollectionResource,
     SaveMixin, DeleteMixin, AutoSaveMixin)
 from .password_reset_token import PasswordResetTokenList
+from .organization import Organization, OrganizationList
+from .organization_account_store_mapping import (
+    OrganizationAccountStoreMapping,
+    OrganizationAccountStoreMappingList)

--- a/stormpath/resources/account_store.py
+++ b/stormpath/resources/account_store.py
@@ -4,11 +4,12 @@
 def AccountStore(client, properties=None):
     """AccountStore resource factory.
 
-    Returns either a Group or a Directory resource, based on the resource
-    href.
+    Returns either a Group or a Directory or an Organization resource,
+    based on the resource href.
     """
     from .directory import Directory
     from .group import Group
+    from .organization import Organization
 
     if not properties or 'href' not in properties:
         raise ValueError('AccountStore called without resource href')
@@ -22,6 +23,8 @@ def AccountStore(client, properties=None):
         return Directory(client, properties=properties)
     elif href.startswith('/groups'):
         return Group(client, properties=properties)
+    elif href.startswith('/organizations'):
+        return Organization(client, properties=properties)
     else:
         raise ValueError('AccountStore called for non-account store href %s' %
             href)

--- a/stormpath/resources/application.py
+++ b/stormpath/resources/application.py
@@ -73,7 +73,7 @@ class Application(Resource, DeleteMixin, DictMixin, AutoSaveMixin, SaveMixin, St
         }
 
     def authenticate_account(self, login, password, expand=None,
-            account_store=None):
+            account_store=None, organization_name_key=None):
         """Authenticate Account inside the Application.
 
         :param login: Username or email address
@@ -88,7 +88,8 @@ class Application(Resource, DeleteMixin, DictMixin, AutoSaveMixin, SaveMixin, St
             object to authenticate against (optional)
         """
         return self.login_attempts.basic_auth(
-            login, password, expand, account_store, app=self)
+            login, password, expand, account_store,
+            organization_name_key=organization_name_key, app=self)
 
     def get_provider_account(self, provider, **provider_kwargs):
         """Used for getting account data from 3rd party Providers

--- a/stormpath/resources/login_attempt.py
+++ b/stormpath/resources/login_attempt.py
@@ -78,7 +78,7 @@ class LoginAttemptList(CollectionResource):
     resource_class = AuthenticationResult
 
     def basic_auth(self, login, password, expand, account_store=None,
-                   app=None):
+                   app=None, organization_name_key=None):
         value = login + ':' + password
         value = b64encode(value.encode('utf-8')).decode('ascii')
         properties = {
@@ -88,6 +88,10 @@ class LoginAttemptList(CollectionResource):
 
         if account_store:
             properties['account_store'] = account_store
+        if organization_name_key:
+            properties['account_store'] = {
+                'name_key': organization_name_key
+            }
 
         result = self.create(properties, expand=expand)
 

--- a/stormpath/resources/organization.py
+++ b/stormpath/resources/organization.py
@@ -1,0 +1,61 @@
+"""Stormpath Organization resource mappings."""
+
+
+from .base import (
+    AutoSaveMixin,
+    CollectionResource,
+    DeleteMixin,
+    DictMixin,
+    Resource,
+    StatusMixin,
+)
+
+
+class Organization(Resource, AutoSaveMixin, DeleteMixin, DictMixin, StatusMixin):
+    """Organization resource.
+    More info in documentation:
+    http://docs.stormpath.com/python/product-guide/#organizations
+    """
+    autosaves = ('custom_data',)
+    writable_attrs = (
+        'custom_data',
+        'description',
+        'name',
+        'name_key',
+        'status',
+    )
+
+    @staticmethod
+    def get_resource_attributes():
+        from .account import AccountList
+        from .account_store_mapping import (
+            AccountStoreMapping,
+            AccountStoreMappingList,
+        )
+        from .custom_data import CustomData
+        from .group import GroupList
+        from .tenant import Tenant
+
+        return {
+            'custom_data': CustomData,
+            'accounts': AccountList,
+            'account_store_mappings': AccountStoreMappingList,
+            'default_account_store_mapping': AccountStoreMapping,
+            'default_group_store_mapping': AccountStoreMapping,
+            'groups': GroupList,
+            'tenant': Tenant,
+        }
+
+
+class OrganizationList(CollectionResource):
+    """Organization resource list."""
+    create_path = '/organizations'
+    resource_class = Organization
+
+    def _ensure_data(self):
+        if self.href == '/organizations':
+            raise ValueError(
+                "It is not possible to access organizations from "
+                "Client resource! Try using Tenant resource instead.")
+
+        super(OrganizationList, self)._ensure_data()

--- a/stormpath/resources/organization_account_store_mapping.py
+++ b/stormpath/resources/organization_account_store_mapping.py
@@ -1,0 +1,55 @@
+"""Stormpath OrganizationAccountStoreMapping resource."""
+
+
+from .base import (
+    CollectionResource,
+    DeleteMixin,
+    DictMixin,
+    Resource,
+    SaveMixin,
+)
+
+
+class OrganizationAccountStoreMapping(Resource, DeleteMixin, DictMixin,
+                                      SaveMixin):
+    """Mapping between an Organization and an Account Store.
+
+    Account Store is a generic term for a resource that stores Accounts.
+    Currently, this includes Directories and Groups.
+
+    More info in documentation:
+    http://docs.stormpath.com/python/product-guide/#adding-an-account-store-to-an-organization
+    """
+    writable_attrs = (
+        'account_store',
+        'organization',
+        'is_default_account_store',
+        'is_default_group_store',
+        'list_index',
+    )
+
+    @staticmethod
+    def get_resource_attributes():
+        from .account_store import AccountStore
+        from .organization import Organization
+
+        return {
+            'account_store': AccountStore,
+            'organization': Organization,
+        }
+
+
+class OrganizationAccountStoreMappingList(CollectionResource):
+    """Organization Account Store Mapping list."""
+
+    create_path = '/organizationAccountStoreMappings'
+    resource_class = OrganizationAccountStoreMapping
+
+    def _ensure_data(self):
+        if self.href == '/organizationAccountStoreMappings':
+            raise ValueError(
+                "It is not possible to access "
+                "organization_account_store_mappings from Client "
+                "resource! Try using Application resource instead.")
+
+        super(OrganizationAccountStoreMappingList, self)._ensure_data()

--- a/stormpath/resources/tenant.py
+++ b/stormpath/resources/tenant.py
@@ -31,6 +31,7 @@ class Tenant(Resource, DeleteMixin, DictMixin, AutoSaveMixin, SaveMixin):
         from .custom_data import CustomData
         from .directory import DirectoryList
         from .group import GroupList
+        from .organization import OrganizationList
 
         return {
             'accounts': AccountList,
@@ -39,4 +40,5 @@ class Tenant(Resource, DeleteMixin, DictMixin, AutoSaveMixin, SaveMixin):
             'custom_data': CustomData,
             'directories': DirectoryList,
             'groups': GroupList,
+            'organizations': OrganizationList,
         }

--- a/tests/live/test_organization.py
+++ b/tests/live/test_organization.py
@@ -1,0 +1,167 @@
+"""Live tests of Organizations functionality."""
+
+from stormpath.resources import Organization
+
+from .base import SingleApplicationBase
+
+
+class TestOrganizations(SingleApplicationBase):
+
+    def test_organization_creation(self):
+        name = self.get_random_name()
+        name_key = name[:63]
+
+        organization = self.client.tenant.organizations.create({
+            'name': name,
+            'description': 'test organization',
+            'name_key': name_key,
+            'status': 'ENABLED'
+        })
+
+        self.assertTrue(organization.is_enabled())
+
+        orgs = self.client.tenant.organizations.query(name=name)
+        self.assertEqual(len(orgs), 1)
+
+        org = orgs[0]
+        self.assertIsInstance(org, Organization)
+        self.assertEqual(org.href, organization.href)
+
+    def test_organization_disabled(self):
+        name = self.get_random_name()
+        name_key = name[:63]
+
+        organization = self.client.tenant.organizations.create({
+            'name': name,
+            'description': 'test organization',
+            'name_key': name_key,
+            'status': 'ENABLED'
+        })
+
+        self.assertTrue(organization.is_enabled())
+
+        orgs = self.client.tenant.organizations.query(name=name)
+        org = orgs[0]
+        org.status = 'DISABLED'
+        org.save()
+
+        orgs = self.client.tenant.organizations.query(name=name)
+        org = orgs[0]
+
+        self.assertIsInstance(org, Organization)
+        self.assertEqual(org.href, organization.href)
+        self.assertTrue(org.is_disabled())
+        self.assertFalse(org.is_enabled())
+
+    def test_organization_deleted(self):
+        name = self.get_random_name()
+        name_key = name[:63]
+
+        organization = self.client.tenant.organizations.create({
+            'name': name,
+            'description': 'test organization',
+            'name_key': name_key,
+            'status': 'ENABLED'
+        })
+
+        organization.delete()
+
+        orgs = self.client.tenant.organizations.query(name=name)
+        self.assertEqual(len(orgs), 0)
+
+    def test_adding_account_store_to_organization(self):
+        name = self.get_random_name()
+        name_key = name[:63]
+
+        organization = self.client.tenant.organizations.create({
+            'name': name,
+            'description': 'test organization',
+            'name_key': name_key,
+            'status': 'ENABLED'
+        })
+
+        oas_mapping = self.client.organization_account_store_mappings.create({
+            'account_store': self.dir,
+            'organization': organization
+        })
+
+        self.assertFalse(oas_mapping.is_default_account_store)
+        self.assertFalse(oas_mapping.is_default_group_store)
+        self.assertEqual(oas_mapping.list_index, 0)
+
+        oas_mapping.delete()
+
+    def test_adding_organization_as_account_store(self):
+        name = self.get_random_name()
+        name_key = name[:63]
+
+        organization = self.client.tenant.organizations.create({
+            'name': name,
+            'description': 'test organization',
+            'name_key': name_key,
+            'status': 'ENABLED'
+        })
+
+        oas_mapping = self.client.organization_account_store_mappings.create({
+            'account_store': self.dir,
+            'organization': organization
+        })
+
+        as_mapping = self.client.account_store_mappings.create({
+            'account_store': organization,
+            'application': self.app
+        })
+
+        self.assertFalse(as_mapping.is_default_account_store)
+        self.assertFalse(as_mapping.is_default_group_store)
+        self.assertEqual(as_mapping.list_index, 1)
+
+        oas_mapping.delete()
+        as_mapping.delete()
+
+    def test_create_account_in_organization(self):
+        name = self.get_random_name()
+        name_key = name[:63]
+
+        organization = self.client.tenant.organizations.create({
+            'name': name,
+            'description': 'test organization',
+            'name_key': name_key,
+            'status': 'ENABLED'
+        })
+
+        oas_mapping = self.client.organization_account_store_mappings.create({
+            'account_store': self.dir,
+            'organization': organization,
+            'list_index': 1,
+            'is_default_account_store': True,
+            'is_default_group_store': True
+        })
+
+        as_mapping = self.client.account_store_mappings.create({
+            'account_store': organization,
+            'application': self.app,
+            'list_index': 1,
+            'is_default_account_store': True,
+            'is_default_group_store': True
+        })
+
+        self.assertTrue(as_mapping.is_default_account_store)
+        self.assertTrue(as_mapping.is_default_group_store)
+        self.assertEqual(as_mapping.list_index, 1)
+
+        acc_name = self.get_random_name()
+        acc_password = 'W00t123!' + acc_name
+        acc_email = acc_name + '@example.com'
+        acc = organization.accounts.create(
+            {
+                'surname': acc_name,
+                'email': acc_email,
+                'password': acc_password,
+                'given_name': acc_name
+            })
+
+        self.assertTrue(acc.given_name, acc_name)
+
+        oas_mapping.delete()
+        as_mapping.delete()


### PR DESCRIPTION
Added Organization (and linked) resource and ability to specify an Organization name_key as an account_store for LoginAttempt (issue #210).