### PR TITLE
Fixed client.groups so it gets groups from Tenant resource.

### DIFF
--- a/stormpath/client.py
+++ b/stormpath/client.py
@@ -83,7 +83,7 @@ class Client(object):
 
     @property
     def groups(self):
-        return GroupList(self, href='/groups')
+        return self.tenant.groups
 
     @property
     def group_memberships(self):

--- a/stormpath/resources/group.py
+++ b/stormpath/resources/group.py
@@ -319,16 +319,10 @@ class GroupList(CollectionResource):
     """Group resource list."""
     resource_class = Group
 
-    def _ensure_data(self):
-        if self.href == '/groups':
-            raise ValueError(
-                "It is not possible to access groups from Client resource! "
-                "Try using Application resource instead.")
-
-        super(GroupList, self)._ensure_data()
-
     def _prepare_for_create(self, properties, expand=None, **params):
-        if self.href == '/groups':
+        href_parts = self.href.split('/')
+        if len(href_parts) >= 3 and href_parts[-1] == 'groups' \
+                and href_parts[-3] == 'tenants':
             raise ValueError(
                 "It is not possible to create groups from Client resource! "
                 "Try using Application or Directory resource instead.")

--- a/tests/live/test_group.py
+++ b/tests/live/test_group.py
@@ -8,9 +8,8 @@ from .base import SingleApplicationBase, AccountBase
 class TestGroups(SingleApplicationBase):
 
     def test_groups_client_iteration(self):
-        with self.assertRaises(ValueError):
-            for group in self.client.groups:
-                pass
+        for group in self.client.groups:
+            group.name
 
     def test_groups_client_create(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
I modified `groups` property on `Client` resource so it gets groups from the tenant.
It is now possible to iterate through groups (as requested in https://github.com/stormpath/stormpath-sdk-python/issues/220 and shown in the modified test).