### PR TITLE
ID Site error JWT support

### DIFF
--- a/stormpath/resources/application.py
+++ b/stormpath/resources/application.py
@@ -17,9 +17,10 @@ from .base import (
     AutoSaveMixin,
 )
 from .login_attempt import LoginAttemptList
+from .password_reset_token import PasswordResetTokenList
+from ..error import Error as StormpathError
 from ..id_site import IdSiteCallbackResult
 from ..nonce import Nonce
-from .password_reset_token import PasswordResetTokenList
 
 
 class Application(Resource, DeleteMixin, DictMixin, AutoSaveMixin, SaveMixin, StatusMixin):
@@ -214,12 +215,14 @@ class Application(Resource, DeleteMixin, DictMixin, AutoSaveMixin, SaveMixin, St
     def handle_id_site_callback(self, url_response):
         """Handles the callback from the ID site.
 
-        :param url_response: A string representing the full url (with it's params) to witch the
-            ID redirected to.
+        :param url_response: A string representing the full url (with
+            it's params) to which the ID redirected to.
 
-        :return: A :class:`stormpath.id_site.IdSiteCallbackResult` object. Which holds the
-            :class:`stormpath.resources.account.Account` object and the state (if any was passed
-            along when creating the redirect uri).
+        :return: A :class:`stormpath.id_site.IdSiteCallbackResult`
+            object. Which holds the
+            :class:`stormpath.resources.account.Account` object and the
+            state (if any was passed along when creating the redirect
+            uri).
 
        """
         try:
@@ -242,6 +245,9 @@ class Application(Resource, DeleteMixin, DictMixin, AutoSaveMixin, SaveMixin, St
                 algorithms=['HS256'])
         except (jwt.DecodeError, jwt.ExpiredSignature):
             return None
+
+        if 'err' in decoded_data:
+            raise StormpathError(decoded_data.get('err'))
 
         nonce = Nonce(decoded_data['irt'])
 

--- a/stormpath/resources/application.py
+++ b/stormpath/resources/application.py
@@ -245,9 +245,17 @@ class Application(Resource, DeleteMixin, DictMixin, AutoSaveMixin, SaveMixin, St
                 algorithms=['HS256'])
         except (jwt.DecodeError, jwt.ExpiredSignature):
             return None
+        except jwt.MissingRequiredClaimError as missing_claim_error:
+            if missing_claim_error.claim != 'aud':
+                return None
 
-        if 'err' in decoded_data:
-            raise StormpathError(decoded_data.get('err'))
+            decoded_data = jwt.decode(
+                jwt_response, api_key_secret, algorithms=['HS256'])
+
+            if 'err' in decoded_data:
+                raise StormpathError(decoded_data.get('err'))
+            else:
+                raise missing_claim_error
 
         nonce = Nonce(decoded_data['irt'])
 

--- a/tests/live/test_resource.py
+++ b/tests/live/test_resource.py
@@ -424,13 +424,10 @@ class TestIdSite(ApiKeyBase):
                 'moreInfo': more_info,
                 'status': status
             },
+            'jti': '6S2TKhkW60uYNhcXLThyPo',
             'exp': now + datetime.timedelta(seconds=3600),
-            'aud': self.app._client.auth.id,
-            'irt': irt,
+            'iat': now,
             'iss': 'Stormpath',
-            'sub': acc.href,
-            'isNewSub': False,
-            'state': None,
         }
 
         fake_jwt = to_unicode(jwt.encode(
@@ -472,13 +469,10 @@ class TestIdSite(ApiKeyBase):
                 'moreInfo': more_info,
                 'status': status
             },
+            'jti': '6S2TKhkW60uYNhcXLThyPo',
             'exp': now + datetime.timedelta(seconds=3600),
-            'aud': self.app._client.auth.id,
-            'irt': irt,
+            'iat': now,
             'iss': 'Stormpath',
-            'sub': acc.href,
-            'isNewSub': False,
-            'state': None,
         }
 
         fake_jwt = to_unicode(jwt.encode(
@@ -521,13 +515,10 @@ class TestIdSite(ApiKeyBase):
                 'moreInfo': more_info,
                 'status': status
             },
+            'jti': '6S2TKhkW60uYNhcXLThyPo',
             'exp': now + datetime.timedelta(seconds=3600),
-            'aud': self.app._client.auth.id,
-            'irt': irt,
+            'iat': now,
             'iss': 'Stormpath',
-            'sub': acc.href,
-            'isNewSub': False,
-            'state': None,
         }
 
         fake_jwt = to_unicode(jwt.encode(
@@ -568,15 +559,10 @@ class TestIdSite(ApiKeyBase):
                 'moreInfo': more_info,
                 'status': status
             },
-            'exp': 3350246665000,
-            'iat': '1407198550',
-            'jti': '436vkkHgk1x3057pCPqTah',
-            'aud': self.app._client.auth.id,
-            'irt': irt,
+            'jti': '6S2TKhkW60uYNhcXLThyPo',
+            'exp': now + datetime.timedelta(seconds=3600),
+            'iat': now,
             'iss': 'Stormpath',
-            'sub': acc.href,
-            'isNewSub': False,
-            'state': None,
         }
 
         fake_jwt = to_unicode(jwt.encode(

--- a/tests/live/test_resource.py
+++ b/tests/live/test_resource.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 
 from oauthlib.common import to_unicode
 from pydispatch import dispatcher
+from stormpath.error import Error
 
 from stormpath.cache.entry import CacheEntry
 from stormpath.resources import Account
@@ -398,3 +399,198 @@ class TestIdSite(ApiKeyBase):
         self.assertIsNotNone(ret)
         self.assertIsNone(ret.account)
         another_app.delete()
+
+    def test_id_site_callback_handler_session_timed_out(self):
+        _, acc = self.create_account(self.app.accounts)
+        now = datetime.datetime.utcnow()
+
+        try:
+            irt = uuid4().get_hex()
+        except AttributeError:
+            irt = uuid4().hex
+
+        code = 12001
+        developer_message = 'The session on ID Site has timed out. This ' + \
+            'can occur if the user stays on ID Site without logging in, ' + \
+            'registering, or resetting a password.'
+        message = 'The session on ID Site has timed out.'
+        more_info = 'mailto:support@stormpath.com'
+        status = 401
+        fake_jwt_data = {
+            'err': {
+                'code': code,
+                'developerMessage': developer_message,
+                'message': message,
+                'moreInfo': more_info,
+                'status': status
+            },
+            'exp': now + datetime.timedelta(seconds=3600),
+            'aud': self.app._client.auth.id,
+            'irt': irt,
+            'iss': 'Stormpath',
+            'sub': acc.href,
+            'isNewSub': False,
+            'state': None,
+        }
+
+        fake_jwt = to_unicode(jwt.encode(
+            fake_jwt_data,
+            self.app._client.auth.secret,
+            'HS256'), 'UTF-8')
+        fake_jwt_response = 'http://localhost/?jwtResponse=%s' % fake_jwt
+        try:
+            self.app.handle_id_site_callback(fake_jwt_response)
+        except Error as e:
+            self.assertEqual(e.code, code)
+            self.assertEqual(e.developer_message, developer_message)
+            self.assertEqual(e.message, developer_message)
+            self.assertEqual(e.more_info, more_info)
+            self.assertEqual(e.status, status)
+        else:
+            self.fail('handle_id_site_callback did not raise expected error.')
+
+    def test_id_site_callback_handler_invalid_token(self):
+        _, acc = self.create_account(self.app.accounts)
+        now = datetime.datetime.utcnow()
+
+        try:
+            irt = uuid4().get_hex()
+        except AttributeError:
+            irt = uuid4().hex
+
+        code = 11001
+        developer_message = 'Token is invalid because the specified ' + \
+            'organization name key does not exist in your Stormpath Tenant'
+        message = 'Token is invalid'
+        more_info = 'mailto:support@stormpath.com'
+        status = 400
+        fake_jwt_data = {
+            'err': {
+                'code': code,
+                'developerMessage': developer_message,
+                'message': message,
+                'moreInfo': more_info,
+                'status': status
+            },
+            'exp': now + datetime.timedelta(seconds=3600),
+            'aud': self.app._client.auth.id,
+            'irt': irt,
+            'iss': 'Stormpath',
+            'sub': acc.href,
+            'isNewSub': False,
+            'state': None,
+        }
+
+        fake_jwt = to_unicode(jwt.encode(
+            fake_jwt_data,
+            self.app._client.auth.secret,
+            'HS256'), 'UTF-8')
+        fake_jwt_response = 'http://localhost/?jwtResponse=%s' % fake_jwt
+        try:
+            self.app.handle_id_site_callback(fake_jwt_response)
+        except Error as e:
+            self.assertEqual(e.code, code)
+            self.assertEqual(e.developer_message, developer_message)
+            self.assertEqual(e.message, developer_message)
+            self.assertEqual(e.more_info, more_info)
+            self.assertEqual(e.status, status)
+        else:
+            self.fail('handle_id_site_callback did not raise expected error.')
+
+    def test_id_site_callback_handler_invalid_cb_uri(self):
+        _, acc = self.create_account(self.app.accounts)
+        now = datetime.datetime.utcnow()
+
+        try:
+            irt = uuid4().get_hex()
+        except AttributeError:
+            irt = uuid4().hex
+
+        code = 400
+        developer_message = 'The specified callback URI (cb_uri) is not ' + \
+            'valid. Make sure the callback URI specified in your ID Site ' + \
+            'configuration matches the value specified.t'
+        message = 'The specified callback URI (cb_uri) is not valid'
+        more_info = 'mailto:support@stormpath.com'
+        status = 400
+        fake_jwt_data = {
+            'err': {
+                'code': code,
+                'developerMessage': developer_message,
+                'message': message,
+                'moreInfo': more_info,
+                'status': status
+            },
+            'exp': now + datetime.timedelta(seconds=3600),
+            'aud': self.app._client.auth.id,
+            'irt': irt,
+            'iss': 'Stormpath',
+            'sub': acc.href,
+            'isNewSub': False,
+            'state': None,
+        }
+
+        fake_jwt = to_unicode(jwt.encode(
+            fake_jwt_data,
+            self.app._client.auth.secret,
+            'HS256'), 'UTF-8')
+        fake_jwt_response = 'http://localhost/?jwtResponse=%s' % fake_jwt
+        try:
+            self.app.handle_id_site_callback(fake_jwt_response)
+        except Error as e:
+            self.assertEqual(e.code, code)
+            self.assertEqual(e.developer_message, developer_message)
+            self.assertEqual(e.message, developer_message)
+            self.assertEqual(e.more_info, more_info)
+            self.assertEqual(e.status, status)
+        else:
+            self.fail('handle_id_site_callback did not raise expected error.')
+
+    def test_id_site_callback_handler_invalid_token_iat(self):
+        _, acc = self.create_account(self.app.accounts)
+
+        try:
+            irt = uuid4().get_hex()
+        except AttributeError:
+            irt = uuid4().hex
+
+        code = 10012
+        developer_message = 'Token is invalid because the issued at time ' + \
+            '(iat) is after the current time'
+        message = 'Token is invalid'
+        more_info = 'mailto:support@stormpath.com'
+        status = 400
+        fake_jwt_data = {
+            'err': {
+                'code': code,
+                'developerMessage': developer_message,
+                'message': message,
+                'moreInfo': more_info,
+                'status': status
+            },
+            'exp': 3350246665000,
+            'iat': '1407198550',
+            'jti': '436vkkHgk1x3057pCPqTah',
+            'aud': self.app._client.auth.id,
+            'irt': irt,
+            'iss': 'Stormpath',
+            'sub': acc.href,
+            'isNewSub': False,
+            'state': None,
+        }
+
+        fake_jwt = to_unicode(jwt.encode(
+            fake_jwt_data,
+            self.app._client.auth.secret,
+            'HS256'), 'UTF-8')
+        fake_jwt_response = 'http://localhost/?jwtResponse=%s' % fake_jwt
+        try:
+            self.app.handle_id_site_callback(fake_jwt_response)
+        except Error as e:
+            self.assertEqual(e.code, code)
+            self.assertEqual(e.developer_message, developer_message)
+            self.assertEqual(e.message, developer_message)
+            self.assertEqual(e.more_info, more_info)
+            self.assertEqual(e.status, status)
+        else:
+            self.fail('handle_id_site_callback did not raise expected error.')

--- a/tests/live/test_resource.py
+++ b/tests/live/test_resource.py
@@ -560,8 +560,8 @@ class TestIdSite(ApiKeyBase):
                 'status': status
             },
             'jti': '6S2TKhkW60uYNhcXLThyPo',
-            'exp': now + datetime.timedelta(seconds=3600),
-            'iat': now,
+            'exp': 3350246665000,
+            'iat': '1407198550',
             'iss': 'Stormpath',
         }
 


### PR DESCRIPTION
Error callbacks from ID site are now handled properly - "err" claim is extracted and raised as `stormpath.error.Error`. This fixes #201  and https://github.com/stormpath/stormpath-django/issues/65 .