### PR TITLE
Added leeway on jwt.decode() calls and tests for it.

### DIFF
--- a/stormpath/api_auth.py
+++ b/stormpath/api_auth.py
@@ -25,6 +25,11 @@ GRANT_TYPE_CLIENT_CREDENTIALS = 'client_credentials'
 GRANT_TYPES = [GRANT_TYPE_CLIENT_CREDENTIALS]
 DEFAULT_TTL = 3600
 
+# Temporary solution for issue #226:
+# Adding 2 s of leeway to account for when there is a clock skew.
+# This should be removed once the "iat" claim from the jwt is removed.
+LEEWAY = datetime.timedelta(seconds=2)
+
 
 class DummyRequest(object):
     """Used to model the same flow for Basic and Bearer"""
@@ -135,7 +140,7 @@ class Token(object):
             try:
                 jwt.decode(
                     self.token, self.app._client.auth.secret,
-                    algorithms=['HS256'], leeway=datetime.timedelta(seconds=2))
+                    algorithms=['HS256'], leeway=LEEWAY)
             except jwt.DecodeError:
                 return False
 

--- a/stormpath/api_auth.py
+++ b/stormpath/api_auth.py
@@ -135,7 +135,7 @@ class Token(object):
             try:
                 jwt.decode(
                     self.token, self.app._client.auth.secret,
-                    algorithms=['HS256'])
+                    algorithms=['HS256'], leeway=datetime.timedelta(seconds=2))
             except jwt.DecodeError:
                 return False
 

--- a/stormpath/resources/application.py
+++ b/stormpath/resources/application.py
@@ -1,6 +1,6 @@
 """Stormpath Application resource mappings."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from uuid import uuid4
 try:
     from urllib import urlencode
@@ -245,7 +245,7 @@ class Application(Resource, DeleteMixin, DictMixin, AutoSaveMixin, SaveMixin, St
         try:
             decoded_data = jwt.decode(
                 jwt_response, api_key_secret, audience=self._client.auth.id,
-                algorithms=['HS256'])
+                algorithms=['HS256'], leeway=timedelta(seconds=2))
         except (jwt.DecodeError, jwt.ExpiredSignature):
             return None
         except jwt.MissingRequiredClaimError as missing_claim_error:
@@ -253,7 +253,8 @@ class Application(Resource, DeleteMixin, DictMixin, AutoSaveMixin, SaveMixin, St
                 return None
 
             decoded_data = jwt.decode(
-                jwt_response, api_key_secret, algorithms=['HS256'])
+                jwt_response, api_key_secret, algorithms=['HS256'],
+                leeway=timedelta(seconds=2))
 
             if 'err' in decoded_data:
                 raise StormpathError(decoded_data.get('err'))

--- a/stormpath/resources/application.py
+++ b/stormpath/resources/application.py
@@ -18,6 +18,7 @@ from .base import (
 )
 from .login_attempt import LoginAttemptList
 from .password_reset_token import PasswordResetTokenList
+from ..api_auth import LEEWAY
 from ..error import Error as StormpathError
 from ..id_site import IdSiteCallbackResult
 from ..nonce import Nonce
@@ -245,7 +246,7 @@ class Application(Resource, DeleteMixin, DictMixin, AutoSaveMixin, SaveMixin, St
         try:
             decoded_data = jwt.decode(
                 jwt_response, api_key_secret, audience=self._client.auth.id,
-                algorithms=['HS256'], leeway=timedelta(seconds=2))
+                algorithms=['HS256'], leeway=LEEWAY)
         except (jwt.DecodeError, jwt.ExpiredSignature):
             return None
         except jwt.MissingRequiredClaimError as missing_claim_error:
@@ -254,7 +255,7 @@ class Application(Resource, DeleteMixin, DictMixin, AutoSaveMixin, SaveMixin, St
 
             decoded_data = jwt.decode(
                 jwt_response, api_key_secret, algorithms=['HS256'],
-                leeway=timedelta(seconds=2))
+                leeway=LEEWAY)
 
             if 'err' in decoded_data:
                 raise StormpathError(decoded_data.get('err'))


### PR DESCRIPTION
This is temporary fix for minor clock skews, as advised in https://github.com/stormpath/stormpath-sdk-python/issues/226#issuecomment-156182755 .