### PR TITLE
Fixed caching for API keys.

### DIFF
--- a/stormpath/client.py
+++ b/stormpath/client.py
@@ -6,6 +6,7 @@ from .data_store import DataStore
 from .http import HttpExecutor
 from .resources.account import AccountList
 from .resources.account_store_mapping import AccountStoreMappingList
+from .resources.api_key import ApiKeyList
 from .resources.agent import AgentList
 from .resources.group import GroupList
 from .resources.group_membership import GroupMembershipList
@@ -68,6 +69,10 @@ class Client(object):
         executor = HttpExecutor(self.BASE_URL, self.auth.scheme, proxies, user_agent=user_agent, get_delay=backoff_strategy)
         self.data_store = DataStore(executor, cache_options)
         self.tenant = Tenant(client=self, href='/tenants/current', expand=expand)
+
+    @property
+    def api_keys(self):
+        return ApiKeyList(self, '/apiKeys')
 
     @property
     def applications(self):

--- a/stormpath/data_store.py
+++ b/stormpath/data_store.py
@@ -137,6 +137,12 @@ class DataStore(object):
         data = self._cache_get(href)
         if data is None:
             data = self.executor.get(href, params=params)
+
+            # If trying to find API key by its ID, put the key in the
+            # cache using its href.
+            if href.split('/')[-1] == 'apiKeys' and 'id' in params:
+                for item in data.get('items'):
+                    self._cache_put(item['href'], item)
             self._cache_put(href, data)
 
         return data

--- a/tests/mocks/test_data_store.py
+++ b/tests/mocks/test_data_store.py
@@ -137,5 +137,38 @@ class TestDataStoreWithMemoryCache(TestCase):
         ex.get.assert_called_once_with('http://example.com/accounts/FOO',
             params=None)
 
+    def test_get_resource_api_keys_is_cached(self):
+
+        ex = MagicMock()
+        ds = DataStore(ex)
+
+        ex.get.return_value = {
+            'href':
+                'https://www.example.com/applications/APPLICATION_ID/apiKeys',
+            'items': [
+                {
+                    'href': 'http://example.com/apiKeys/KEY_ID',
+                    'id': 'KEY_ID',
+                    'secret': 'KEY_SECRET'
+                }
+            ]
+        }
+
+        ds.get_resource(
+            'https://www.example.com/applications/APPLICATION_ID/apiKeys',
+            {'id': 'KEY_ID'})
+
+        ex.get.assert_called_once_with(
+            'https://www.example.com/applications/APPLICATION_ID/apiKeys',
+            params={'id': 'KEY_ID'})
+
+        self.assertEqual(
+            ds._cache_get('http://example.com/apiKeys/KEY_ID'),
+            {
+                'secret': 'KEY_SECRET',
+                'href': 'http://example.com/apiKeys/KEY_ID',
+                'id': 'KEY_ID'
+            })
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
When getting an API key by its ID (get_key()), try to get it from the cache using its ID.
If the key is not in the cache, make HTTP request to the Stormpath service to get the key and put it in the cache.
This fixes #231 .