### PR TITLE
Error message as value for developerMessage key only when needed.

### DIFF
--- a/stormpath/http.py
+++ b/stormpath/http.py
@@ -122,7 +122,13 @@ class HttpExecutor(object):
             ret = "An unexpected error occurred. HTTP Status code: %s. " % r.status_code
             ret += "Error message: %s. " % e
             ret += "Consider setting the logging level to debug for more detail."
-        raise Error({'developerMessage': ret}, http_status=r.status_code)
+
+        if not isinstance(ret, dict):
+            ret = {'developerMessage': ret}
+        elif 'developerMessage' not in ret:
+            ret['developerMessage'] = ret
+
+        raise Error(ret, http_status=r.status_code)
 
     def return_response(self, r):
         if not r.text:

--- a/tests/live/test_error.py
+++ b/tests/live/test_error.py
@@ -1,0 +1,31 @@
+"""Live tests of common error functionality.
+
+We can use (almost) any resource here - Account is a convenient choice.
+"""
+
+from .base import AuthenticatedLiveBase
+from stormpath.resources import Account
+from stormpath.error import Error
+
+
+class TestError(AuthenticatedLiveBase):
+
+    def test_error_raised_with_error_json(self):
+        error = None
+
+        try:
+            acc = Account(
+                self.client, '%s/i.do.not.exist' % self.client.BASE_URL)
+            acc.given_name
+        except Error as e:
+            error = e
+
+        self.assertIsNotNone(error)
+        self.assertIsInstance(error, Error)
+        msg = str(error)
+        self.assertEqual(error.status, 404)
+        self.assertEqual(error.code, 404)
+        self.assertEqual(error.developer_message, msg)
+        self.assertEqual(error.user_message, msg)
+        self.assertTrue(error.more_info)
+        self.assertEqual(error.message, msg)


### PR DESCRIPTION
If error message is already a dict with `developerMessage` in it, there is no need to set it as value for another `developerMessage` key.
This caused weird behaviour described in https://github.com/stormpath/stormpath-sdk-python/issues/236 .
Old code used to pass dict with this format:
```
{
    'developerMessage': {
        'status': STATUS,
        'developerMessage': DEV_MSG,
        'message': USR_MSG,
        'code': CODE,
        'moreInfo': MORE_INFO
    }
}
```
in case proper dict was returned from Stormpath. This was introduced in https://github.com/stormpath/stormpath-sdk-python/commit/d741d2e815518bd99ba20885517025bea12f9366 while trying to fix the case when Error constructor doesn't get a dict.