### PR TITLE
Fix for forked builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ matrix:
   - env: BUILD_DOCS=true
     python: '2.7'
 before_install:
-- test -z "$BUILD_DOCS" || openssl aes-256-cbc -K $encrypted_09e6ef1dc349_key -iv $encrypted_09e6ef1dc349_iv
-  -in keypair.enc -out ~/.ssh/id_rsa -d
-- test -z "$BUILD_DOCS" || chmod 600 ~/.ssh/id_rsa
+- if [ $TRAVIS_PULL_REQUEST == 'false' ]; then
+    test -z "$BUILD_DOCS" || openssl aes-256-cbc -K $encrypted_09e6ef1dc349_key -iv $encrypted_09e6ef1dc349_iv -in keypair.enc -out ~/.ssh/id_rsa -d;
+    test -z "$BUILD_DOCS" || chmod 600 ~/.ssh/id_rsa;
+  fi


### PR DESCRIPTION
Part of Travis tests fail due to PRs being across forks. This .travis.yml edit should take care of that - it skips those tests on forked builds (tests where BUILD_DOCS=true).