### PR TITLE
Incorrect Error code for updating an account's email with a email-id that is already in use

### DIFF
--- a/tests/live/test_account.py
+++ b/tests/live/test_account.py
@@ -172,6 +172,22 @@ class TestAccountCreateUpdateDelete(AccountBase):
         self.assertEqual(acc.custom_data['key'], 'value')
         self.assertTrue(accs[0].is_enabled())
 
+    # As agreed with Randall - this test will be commented out
+    # but it should be back in when the status/code bug in Stormpath REST API
+    # is resolved
+
+    # def test_update_account_with_existing_email(self):
+    #     _, account1 = self.create_account(self.app.accounts)
+    #     _, account2 = self.create_account(self.app.accounts)
+    #
+    #     account2.email = account1.email
+    #
+    #     try:
+    #         account2.save()
+    #     except Error as err:
+    #         self.assertEqual(err.code, 2001)
+    #         self.assertEqual(err.status, 409)
+
 
 class TestApplicationAuthentication(AccountBase):
 


### PR DESCRIPTION
Test that will be uncommented when the issue is fixed on Strompath's end #265